### PR TITLE
Workspace API: warehouse-aware deploy, plain folders, nested pipeline repoint

### DIFF
--- a/duckrun/workspace.py
+++ b/duckrun/workspace.py
@@ -352,11 +352,15 @@ class Workspace:
         """Every lakehouse in the workspace as ``[{"displayName": ..., "id": ...}, ...]``."""
         return self._items("lakehouses")
 
-    def create_lakehouse(self, name: str, schemas: bool = True) -> str:
+    def create_lakehouse(self, name: str, schemas: bool = True,
+                         folder: Optional[str] = None) -> str:
         """Ensure a lakehouse named ``name`` exists; return its item id.
 
-        Idempotent: if one already exists it is returned unchanged (no create). ``schemas=True``
-        makes it schema-enabled. Raises :class:`RemoteRunError` on a real API failure.
+        Idempotent: if one already exists it is returned unchanged (no create) — and left where
+        it already lives, so ``folder`` only places a lakehouse this call CREATES. ``schemas=True``
+        makes it schema-enabled. ``folder`` names a workspace folder (created at the root if
+        absent), the same placement ``deploy(folder=...)`` does. Raises :class:`RemoteRunError` on
+        a real API failure.
         """
         for lh in self._items("lakehouses"):
             if lh.get("displayName") == name:
@@ -364,6 +368,8 @@ class Workspace:
         body: Dict = {"displayName": name}
         if schemas:
             body["creationPayload"] = {"enableSchemas": True}
+        if folder:
+            body["folderId"] = _ensure_folder(self._token, self.id, folder, required=True)
         resp = _http_request(
             "POST", f"{_FABRIC_API}/workspaces/{self.id}/lakehouses", token=self._token, json_body=body
         )
@@ -374,19 +380,23 @@ class Workspace:
         resp.raise_for_status()
         raise RemoteRunError(f"unexpected status {resp.status_code} creating lakehouse: {resp.text[:200]}")
 
-    def create_warehouse(self, name: str) -> str:
+    def create_warehouse(self, name: str, folder: Optional[str] = None) -> str:
         """Ensure a warehouse named ``name`` exists; return its item id.
 
         The warehouse sibling of :meth:`create_lakehouse` — idempotent (an existing one is returned
-        unchanged, no create), 202-aware (a create is a long-running operation, polled to
-        completion). Its SQL endpoint is :meth:`sql_endpoint`. Raises :class:`RemoteRunError` on a
-        real API failure.
+        unchanged, no create, and stays where it lives), 202-aware (a create is a long-running
+        operation, polled to completion), and ``folder`` places one it CREATES in that workspace
+        folder. Its SQL endpoint is :meth:`sql_endpoint`. Raises :class:`RemoteRunError` on a real
+        API failure.
         """
         for wh in self._items("warehouses"):
             if wh.get("displayName") == name:
                 return wh["id"]
+        body: Dict = {"displayName": name}
+        if folder:
+            body["folderId"] = _ensure_folder(self._token, self.id, folder, required=True)
         resp = _http_request("POST", f"{_FABRIC_API}/workspaces/{self.id}/warehouses",
-                             token=self._token, json_body={"displayName": name})
+                             token=self._token, json_body=body)
         if resp.status_code in (200, 201):
             return resp.json()["id"]
         if resp.status_code == 202:

--- a/duckrun/workspace.py
+++ b/duckrun/workspace.py
@@ -140,6 +140,20 @@ def _is_pipeline_json(obj) -> bool:
         and "activities" in obj["properties"]
 
 
+def _walk_activities(activities):
+    """Every activity in ``activities``, recursing into container activities — ForEach/Until carry
+    nested ``typeProperties.activities``, If ``ifTrueActivities``/``ifFalseActivities``, Switch
+    ``cases[].activities`` + ``defaultActivities`` — so a notebook activity is found wherever it
+    sits, not only at the top level."""
+    for act in activities or []:
+        yield act
+        tp = act.get("typeProperties") or {}
+        for key in ("activities", "ifTrueActivities", "ifFalseActivities", "defaultActivities"):
+            yield from _walk_activities(tp.get(key))
+        for case in tp.get("cases") or []:
+            yield from _walk_activities(case.get("activities"))
+
+
 def _is_variable_library_json(obj) -> bool:
     """Whether ``obj`` (parsed JSON) is a variable-library ``variables.json`` — ``{"variables": [...]}``."""
     return isinstance(obj, dict) and isinstance(obj.get("variables"), list)
@@ -175,22 +189,64 @@ def _read_source(source: str) -> bytes:
         return f.read()
 
 
+def _scan_loose_files(folder: str) -> List[Dict]:
+    """The deployable loose files directly under ``folder`` — a plain directory of ``.ipynb`` /
+    ``.bim`` / ``.json`` sources with no git-integration layout (e.g. a repo's ``notebooks/``).
+    Each file is typed by its extension (a ``.json`` by sniffing pipeline vs variable library,
+    exactly like the single-file deploy) and named by its stem; returned in dependency order.
+    Not recursive: only the folder's own files, so a nested project tree isn't swept up by
+    accident."""
+    items = []
+    for fname in sorted(os.listdir(folder)):
+        path = os.path.join(folder, fname)
+        stem, ext = os.path.splitext(fname)
+        ext = ext.lower()
+        if not os.path.isfile(path) or ext not in _DEPLOY_EXT:
+            continue
+        if ext == ".ipynb":
+            item_type = "Notebook"
+        elif ext == ".bim":
+            item_type = "SemanticModel"
+        else:
+            try:
+                with open(path, "rb") as f:
+                    obj = json.load(f)
+            except ValueError as exc:
+                raise RemoteRunError(f"{path!r} is not valid JSON: {exc}")
+            if _is_pipeline_json(obj):
+                item_type = "DataPipeline"
+            elif _is_variable_library_json(obj):
+                item_type = "VariableLibrary"
+            else:
+                raise RemoteRunError(
+                    f"{path!r} is neither a Fabric data pipeline (properties.activities) nor a "
+                    "variable library (variables)")
+        items.append({"type": item_type, "name": stem, "primary": path})
+    items.sort(key=lambda it: _DEPLOY_ORDER.index(it["type"]))
+    return items
+
+
 def _scan_item_folders(folder: str) -> List[Dict]:
     """The Fabric items under ``folder`` (git-integration layout: one ``name.ItemType`` subfolder
     per item, each holding a ``.platform`` metadata file). Returns, in dependency order, one
     ``{"type", "name", "primary"}`` per item — ``name`` is the ``.platform`` displayName and
     ``primary`` the definition file the single-file deploy path consumes. Pointing at an item
-    folder itself (``.../run.Notebook``) yields just that item. Unknown types and malformed
-    folders raise rather than skip: a partial deploy that looked complete is worse than a loud
-    failure."""
+    folder itself (``.../run.Notebook``) yields just that item. A folder with no ``.platform``
+    items falls back to its loose deployable files (``_scan_loose_files``). Unknown types and
+    malformed folders raise rather than skip: a partial deploy that looked complete is worse
+    than a loud failure."""
     if os.path.isfile(os.path.join(folder, ".platform")):
         dirs = [folder]                     # an item folder itself, not a folder of items
     else:
         dirs = sorted(os.path.join(folder, d) for d in os.listdir(folder)
                       if os.path.isfile(os.path.join(folder, d, ".platform")))
     if not dirs:
+        loose = _scan_loose_files(folder)
+        if loose:
+            return loose
         raise RemoteRunError(
-            f"no Fabric items under {folder!r} (no subfolder has a .platform file)")
+            f"no Fabric items under {folder!r} (no subfolder has a .platform file, and no "
+            f"loose {'/'.join(_DEPLOY_EXT)} files)")
     items = []
     for d in dirs:
         platform = os.path.join(d, ".platform")
@@ -217,12 +273,13 @@ def _scan_item_folders(folder: str) -> List[Dict]:
 
 
 def _has_notebook_activity(primary: str) -> bool:
-    """Whether a ``pipeline-content.json`` has a ``TridentNotebook`` activity — i.e. anything a
-    notebook repoint could rewrite (``_repoint_pipeline`` raises on a pipeline without one)."""
+    """Whether a ``pipeline-content.json`` has a ``TridentNotebook`` activity — however deeply
+    nested — i.e. anything a notebook repoint could rewrite (``_repoint_pipeline`` raises on a
+    pipeline without one)."""
     with open(primary, "rb") as f:
         obj = json.load(f)
     activities = (obj.get("properties") or {}).get("activities") or []
-    return any(act.get("type") == "TridentNotebook" for act in activities)
+    return any(act.get("type") == "TridentNotebook" for act in _walk_activities(activities))
 
 
 class ScriptResult:
@@ -313,7 +370,10 @@ class Workspace:
         ``{displayName: item id}``. Names come from each item's ``.platform``; a pipeline's
         notebook activities are automatically pointed at the folder's notebook when it has exactly
         one (``notebook=`` picks one otherwise). Each item honours ``lakehouse`` / ``variables`` /
-        ``overwrite`` exactly as a single-file deploy of that item would.
+        ``overwrite`` exactly as a single-file deploy of that item would. A **plain folder** with
+        no ``.platform`` items works too: its loose ``.ipynb`` / ``.bim`` / ``.json`` files (top
+        level only) deploy the same way, each named by its filename stem — so
+        ``ws.deploy("notebooks", overwrite=True)`` ships a repo's whole notebook directory.
 
         A **file** ``source`` is a local path or an ``http(s)`` URL (a raw file URL), and the item
         id is returned. The item type is keyed off the extension — ``.ipynb`` → notebook, ``.bim`` → semantic model, ``.json`` → a data
@@ -596,7 +656,7 @@ class Workspace:
         obj = json.loads(content)
         activities = (obj.get("properties") or {}).get("activities") or []
         repointed = 0
-        for act in activities:
+        for act in _walk_activities(activities):
             if act.get("type") == "TridentNotebook":
                 tp = act.setdefault("typeProperties", {})
                 tp["notebookId"] = nb_id

--- a/duckrun/workspace.py
+++ b/duckrun/workspace.py
@@ -8,6 +8,7 @@ rather than on the :class:`~duckrun.session.DuckSession` that ``connect()`` retu
     import duckrun
     ws = duckrun.workspace("My Workspace")            # name or GUID
     ws.create_lakehouse("bronze")                     # provision an empty container (by name)
+    ws.create_warehouse("gold_dwh")                   # same, for a warehouse
     ws.deploy("etl.ipynb")                            # deploy a file artifact (a notebook)
     ws.deploy("model.bim")                            # deploy + refresh a semantic model
     ws.deploy("fabric_items")                         # deploy a whole folder of items at once
@@ -138,6 +139,14 @@ _DOWNLOAD_FMT = {"Notebook": "ipynb", "SemanticModel": "TMSL"}
 _RUNNABLE = {"notebooks": "RunNotebook", "dataPipelines": "Pipeline"}
 # Which collections to look in for a given source extension when running by file name.
 _RUN_EXT = {".ipynb": ["notebooks"], ".json": ["dataPipelines"]}
+
+
+def _is_directlake_bim(content: bytes) -> bool:
+    """Whether a ``model.bim`` is Direct Lake — it declares a ``directLake`` partition mode, or
+    carries a OneLake table reference. Checked on the ORIGINAL bytes, before any repoint rewrites
+    the ids. A Direct Lake model is reframed after deploy; a DirectQuery-only one is not."""
+    text = content.decode("utf-8")
+    return "directLake" in text or bool(_ONELAKE_REF.search(text))
 
 
 def _is_pipeline_json(obj) -> bool:
@@ -365,6 +374,26 @@ class Workspace:
         resp.raise_for_status()
         raise RemoteRunError(f"unexpected status {resp.status_code} creating lakehouse: {resp.text[:200]}")
 
+    def create_warehouse(self, name: str) -> str:
+        """Ensure a warehouse named ``name`` exists; return its item id.
+
+        The warehouse sibling of :meth:`create_lakehouse` — idempotent (an existing one is returned
+        unchanged, no create), 202-aware (a create is a long-running operation, polled to
+        completion). Its SQL endpoint is :meth:`sql_endpoint`. Raises :class:`RemoteRunError` on a
+        real API failure.
+        """
+        for wh in self._items("warehouses"):
+            if wh.get("displayName") == name:
+                return wh["id"]
+        resp = _http_request("POST", f"{_FABRIC_API}/workspaces/{self.id}/warehouses",
+                             token=self._token, json_body={"displayName": name})
+        if resp.status_code in (200, 201):
+            return resp.json()["id"]
+        if resp.status_code == 202:
+            return _await_lro_item_id(self._token, resp)
+        resp.raise_for_status()
+        raise RemoteRunError(f"unexpected status {resp.status_code} creating warehouse: {resp.text[:200]}")
+
     def deploy(self, source: str, lakehouse: Optional[str] = None, variables: Optional[Dict] = None,
                name: Optional[str] = None, overwrite: bool = False,
                notebook: Optional[str] = None,
@@ -439,6 +468,7 @@ class Workspace:
             endpoint = "notebooks"
         elif ext == ".bim":
             endpoint = "semanticModels"
+            directlake = _is_directlake_bim(content)                  # before ids are rewritten
             content = self._repoint_bim(content, lakehouse, source)   # resolve before any delete
             content = self._repoint_dq_bim(content, warehouse, source)
         else:                                                          # .json → pipeline or variable library
@@ -468,7 +498,7 @@ class Workspace:
         # queries live — so no refresh.
         item_id = _create_semantic_model(self._token, self.id, name, content, item_id=item_id,
                                          folder_id=folder_id)
-        if _ONELAKE_REF.search(content.decode("utf-8")):
+        if directlake:
             _refresh_semantic_model(get_powerbi_token(), self.id, item_id)
         return item_id
 

--- a/duckrun/workspace.py
+++ b/duckrun/workspace.py
@@ -29,6 +29,13 @@ from urllib.parse import urlsplit
 _ONELAKE_REF = re.compile(
     r"onelake\.dfs\.fabric\.microsoft\.com/([0-9a-fA-F-]{36})/([0-9a-fA-F-]{36})")
 
+# A DirectQuery-on-warehouse model.bim references its warehouse through M expressions like
+# Sql.Database("<endpoint>.datawarehouse.fabric.microsoft.com", "<warehouse>"). The bim is JSON,
+# so in the raw text the quotes appear escaped (\") — the pattern tolerates both forms.
+_SQL_DATABASE_REF = re.compile(
+    r'Sql\.Database\(\\?"(?P<server>[^"\\]+\.datawarehouse\.fabric\.microsoft\.com)\\?",'
+    r'\s*\\?"(?P<db>[^"\\]+)\\?"')
+
 from .auth import get_fabric_token, get_onelake_token, get_powerbi_token
 from .fabric_remote import (
     _FABRIC_API,
@@ -361,6 +368,7 @@ class Workspace:
     def deploy(self, source: str, lakehouse: Optional[str] = None, variables: Optional[Dict] = None,
                name: Optional[str] = None, overwrite: bool = False,
                notebook: Optional[str] = None,
+               warehouse: Optional[str] = None,
                folder: Optional[str] = None) -> Union[str, Dict[str, str]]:
         """Deploy a file artifact — or a whole folder of items — to the workspace.
 
@@ -387,6 +395,14 @@ class Workspace:
         when the model already targets a lakehouse in this workspace, or the workspace has exactly one;
         with several you must name it.
 
+        ``warehouse`` (a warehouse name in this workspace) is the sibling for a **DirectQuery** ``.bim``:
+        duckrun rewrites every ``Sql.Database("<endpoint>.datawarehouse.fabric.microsoft.com", "<db>")``
+        reference to this workspace's SQL endpoint (:meth:`sql_endpoint`) and that warehouse — so the
+        model connects to the right warehouse by NAME, wherever the bim was authored. Inferred when
+        the referenced database name matches a warehouse here, or the workspace has exactly one. A
+        Direct Lake model is refreshed after deploy; a DirectQuery-only model is NOT (nothing to
+        reframe — it queries live).
+
         ``notebook`` (a notebook name in this workspace) points a **data pipeline**'s notebook
         activities at that notebook: duckrun rewrites the ``notebookId`` / ``workspaceId`` GUIDs baked
         into the pipeline JSON to that notebook's id and this workspace — so a pipeline authored
@@ -404,13 +420,13 @@ class Workspace:
         notebooks' best-effort temp parking, an explicitly requested ``folder`` raises if it
         cannot be resolved.
 
-        ``lakehouse`` / ``notebook`` / ``variables`` are ignored for artifact types they don't apply
-        to. Not idempotent: if an item of that name already exists it is replaced only when
-        ``overwrite=True``, otherwise this raises.
+        ``lakehouse`` / ``warehouse`` / ``notebook`` / ``variables`` are ignored for artifact types
+        they don't apply to. Not idempotent: if an item of that name already exists it is replaced
+        only when ``overwrite=True``, otherwise this raises.
         """
         if os.path.isdir(source):
             return self._deploy_folder(source, lakehouse, variables, name, overwrite, notebook,
-                                       folder)
+                                       warehouse, folder)
         stem, ext = os.path.splitext(_basename(source))
         ext = ext.lower()
         if ext not in _DEPLOY_EXT:
@@ -424,6 +440,7 @@ class Workspace:
         elif ext == ".bim":
             endpoint = "semanticModels"
             content = self._repoint_bim(content, lakehouse, source)   # resolve before any delete
+            content = self._repoint_dq_bim(content, warehouse, source)
         else:                                                          # .json → pipeline or variable library
             endpoint, content = self._json_artifact(source, content, variables, notebook)
 
@@ -446,20 +463,27 @@ class Workspace:
         if endpoint == "variableLibraries":
             return _create_variable_library(self._token, self.id, name, content, item_id=item_id,
                                             folder_id=folder_id)
-        # semanticModels → create/update, then refresh/reframe so it is live.
+        # semanticModels → create/update; a Direct Lake model is then refreshed (a reframe onto the
+        # latest Delta data) so it is live. A DirectQuery-only model has nothing to reframe — it
+        # queries live — so no refresh.
         item_id = _create_semantic_model(self._token, self.id, name, content, item_id=item_id,
                                          folder_id=folder_id)
-        _refresh_semantic_model(get_powerbi_token(), self.id, item_id)
+        if _ONELAKE_REF.search(content.decode("utf-8")):
+            _refresh_semantic_model(get_powerbi_token(), self.id, item_id)
         return item_id
 
     def _deploy_folder(self, folder: str, lakehouse: Optional[str], variables: Optional[Dict],
                        name: Optional[str], overwrite: bool, notebook: Optional[str],
+                       warehouse: Optional[str] = None,
                        ws_folder: Optional[str] = None) -> Dict[str, str]:
         """Deploy every Fabric item under ``folder`` in dependency order; return
         ``{displayName: item id}``. Each item recurses through the single-file ``deploy``, so the
-        Direct Lake repoint, variable injection, semantic-model refresh and ``overwrite`` semantics
-        are all the single-file behavior. A pipeline is pointed at the folder's sole notebook when
-        it has a notebook activity and no explicit ``notebook=`` was given."""
+        Direct Lake / warehouse repoints, variable injection, semantic-model refresh and
+        ``overwrite`` semantics are all the single-file behavior. A pipeline is pointed at the
+        folder's sole notebook when it has a notebook activity and no explicit ``notebook=`` was
+        given. ``lakehouse`` / ``warehouse`` are forwarded to each ``.bim`` only when the model
+        actually carries that kind of reference — so a mixed folder (Direct Lake + DirectQuery
+        models) deploys with both named, each bim getting the rewrite that applies to it."""
         if name is not None:
             raise RemoteRunError("name= applies to a single-file deploy; folder items are named "
                                  "by their .platform displayName")
@@ -468,12 +492,20 @@ class Workspace:
         ids: Dict[str, str] = {}
         for it in items:
             nb = notebook
+            lh, wh = lakehouse, warehouse
             if it["type"] == "DataPipeline" and nb is None and len(notebooks) == 1 \
                     and _has_notebook_activity(it["primary"]):
                 nb = notebooks[0]
-            ids[it["name"]] = self.deploy(it["primary"], lakehouse=lakehouse, variables=variables,
+            if it["type"] == "SemanticModel" and (lh is not None or wh is not None):
+                with open(it["primary"], encoding="utf-8") as f:
+                    text = f.read()
+                if lh is not None and not _ONELAKE_REF.search(text):
+                    lh = None               # not Direct Lake — lakehouse= doesn't apply to this bim
+                if wh is not None and not _SQL_DATABASE_REF.search(text):
+                    wh = None               # no warehouse reference — warehouse= doesn't apply
+            ids[it["name"]] = self.deploy(it["primary"], lakehouse=lh, variables=variables,
                                           name=it["name"], overwrite=overwrite, notebook=nb,
-                                          folder=ws_folder)
+                                          warehouse=wh, folder=ws_folder)
         return ids
 
     def download(self, folder: str = ".", name: Optional[str] = None,
@@ -675,6 +707,83 @@ class Workspace:
             return match["id"]
         have = ", ".join(sorted(it.get("displayName", "?") for it in self._items("notebooks"))) or "(none)"
         raise RemoteRunError(f"notebook {name!r} not found in workspace {self.id}; have: {have}")
+
+    def sql_endpoint(self, warehouse: Optional[str] = None) -> str:
+        """The workspace's SQL/TDS endpoint hostname — e.g.
+        ``xxxx-yyyy.datawarehouse.fabric.microsoft.com`` — what a connection string's ``Server=``
+        takes and what a DirectQuery bim's ``Sql.Database()`` references. The hostname is
+        workspace-scoped: every warehouse and lakehouse SQL analytics endpoint in the workspace
+        shares it. ``warehouse`` names the warehouse to read it from (raises listing the real names
+        on a miss); omitted, any warehouse serves, falling back to a lakehouse's SQL analytics
+        endpoint when the workspace has no warehouse at all."""
+        warehouses = self._items("warehouses")
+        if warehouse is not None:
+            match = next((w for w in warehouses if w.get("displayName") == warehouse), None)
+            if not match:
+                have = ", ".join(sorted(w.get("displayName", "?") for w in warehouses)) or "(none)"
+                raise RemoteRunError(
+                    f"warehouse {warehouse!r} not found in workspace {self.id}; have: {have}")
+            warehouses = [match]
+        for w in warehouses:
+            resp = _http_request("GET", f"{_FABRIC_API}/workspaces/{self.id}/warehouses/{w['id']}",
+                                 token=self._token)
+            resp.raise_for_status()
+            endpoint = (resp.json().get("properties") or {}).get("connectionString")
+            if endpoint:
+                return endpoint
+        for lh in self._items("lakehouses"):
+            resp = _http_request("GET", f"{_FABRIC_API}/workspaces/{self.id}/lakehouses/{lh['id']}",
+                                 token=self._token)
+            resp.raise_for_status()
+            endpoint = ((resp.json().get("properties") or {})
+                        .get("sqlEndpointProperties") or {}).get("connectionString")
+            if endpoint:
+                return endpoint
+        raise RemoteRunError(f"no SQL endpoint found in workspace {self.id} "
+                             "(no warehouse or lakehouse exposes a connectionString)")
+
+    def _repoint_dq_bim(self, content: bytes, warehouse: Optional[str], source: str) -> bytes:
+        """Rewrite a DirectQuery ``model.bim``'s ``Sql.Database(server, db)`` references to this
+        workspace's SQL endpoint and the chosen warehouse — the warehouse sibling of
+        ``_repoint_bim``. If the model carries no warehouse reference it isn't
+        DirectQuery-on-warehouse, so it's returned unchanged (and an explicit ``warehouse=`` then
+        raises — nothing to point)."""
+        text = content.decode("utf-8")
+        m = _SQL_DATABASE_REF.search(text)
+        if not m:
+            if warehouse is not None:
+                raise RemoteRunError(
+                    f"{source!r} has no Sql.Database(...datawarehouse.fabric.microsoft.com) "
+                    f"reference to point at warehouse {warehouse!r} "
+                    "(is it a DirectQuery-on-warehouse model?)")
+            return content
+        target = self._resolve_warehouse(warehouse, m.group("db"))
+        server = self.sql_endpoint(target)
+
+        def _swap(match):
+            call = match.group(0)
+            call = call.replace(match.group("server"), server)
+            return call.replace(match.group("db"), target)
+
+        return _SQL_DATABASE_REF.sub(_swap, text).encode("utf-8")
+
+    def _resolve_warehouse(self, warehouse: Optional[str], source_db: str) -> str:
+        """The target warehouse NAME for a DirectQuery repoint. Named → verified to exist (raise
+        listing the real names). Unnamed → the warehouse the model already references if it lives
+        here, else the sole warehouse, else raise asking which one."""
+        warehouses = self._items("warehouses")
+        names = [w.get("displayName") for w in warehouses]
+        if warehouse is not None:
+            if warehouse not in names:
+                raise RemoteRunError(f"warehouse {warehouse!r} not found in workspace; have: {names}")
+            return warehouse
+        if source_db in names:
+            return source_db                # already references a warehouse here — keep it
+        if len(warehouses) == 1:
+            return names[0]
+        if not warehouses:
+            raise RemoteRunError("no warehouse in this workspace to point the model at")
+        raise RemoteRunError(f"which warehouse should the model use? pass warehouse=; have: {names}")
 
     def _repoint_bim(self, content: bytes, lakehouse: Optional[str], source: str) -> bytes:
         """Rewrite a Direct-Lake ``model.bim``'s OneLake workspace/lakehouse GUIDs to this workspace

--- a/tests/fabric_remote/test_workspace.py
+++ b/tests/fabric_remote/test_workspace.py
@@ -468,6 +468,27 @@ def test_repoint_pipeline_points_notebook_by_name(_patch):
     assert acts[1] == {"type": "Wait", "typeProperties": {"waitTimeInSeconds": 1}}   # untouched
 
 
+def test_repoint_pipeline_reaches_nested_activities(_patch):
+    # A notebook activity buried in containers (ForEach sweep, If branch) is repointed too — the
+    # walk recurses through typeProperties.activities / ifTrueActivities / ifFalseActivities /
+    # Switch cases, not just the top level.
+    _patch(DeployFabric(kind="notebooks", existing=[{"displayName": "run", "id": "nb-123"}]))
+    ws = _ws()
+    pipeline = json.dumps({"properties": {"activities": [
+        {"type": "ForEach", "typeProperties": {"isSequential": True, "activities": [
+            {"type": "TridentNotebook", "typeProperties": {"notebookId": "SRC-NB", "workspaceId": "SRC-WS"}},
+        ]}},
+        {"type": "If", "typeProperties": {"ifTrueActivities": [
+            {"type": "TridentNotebook", "typeProperties": {"notebookId": "SRC-NB2", "workspaceId": "SRC-WS"}},
+        ]}},
+    ]}}).encode()
+    acts = json.loads(ws._repoint_pipeline(pipeline, "run"))["properties"]["activities"]
+    inner = acts[0]["typeProperties"]["activities"][0]["typeProperties"]
+    branch = acts[1]["typeProperties"]["ifTrueActivities"][0]["typeProperties"]
+    assert inner == {"notebookId": "nb-123", "workspaceId": "ws-guid"}
+    assert branch == {"notebookId": "nb-123", "workspaceId": "ws-guid"}
+
+
 def test_repoint_pipeline_none_is_verbatim(_patch):
     _patch(DeployFabric(kind="notebooks"))
     content = json.dumps({"properties": {"activities": []}}).encode()
@@ -727,6 +748,42 @@ def test_deploy_folder_overwrite_forwarded(_patch, tmp_path):
     assert any(m == "POST" and u.endswith("/notebooks/old-nb/updateDefinition")
                for m, u, _ in fake.calls)
     assert fake.created() == []                                           # never a fresh create
+
+
+def test_deploy_loose_folder_by_extension(_patch, monkeypatch, tmp_path):
+    # A plain folder — no .platform layout, just files — deploys each loose .ipynb/.bim/.json by
+    # extension, named by stem, in dependency order; the pipeline's NESTED notebook activity is
+    # automagically pointed at the folder's sole notebook.
+    fake = _patch(MultiDeployFabric())
+    root = tmp_path / "notebooks"
+    root.mkdir()
+    (root / "etl.ipynb").write_text(_NB_JSON, encoding="utf-8")
+    (root / "sweep.json").write_text(json.dumps({"properties": {"activities": [
+        {"type": "ForEach", "typeProperties": {"activities": [
+            {"type": "TridentNotebook", "typeProperties": {"notebookId": "SRC-NB", "workspaceId": "SRC-WS"}},
+        ]}}]}}), encoding="utf-8")
+    ids = _ws().deploy(str(root))
+    assert ids == {"etl": "item-1", "sweep": "item-2"}
+    assert fake.created() == ["notebooks", "dataPipelines"]      # notebook first, pipeline last
+    out = json.loads(_decoded_part(fake, "/workspaces/ws-guid/dataPipelines", "pipeline-content.json"))
+    inner = out["properties"]["activities"][0]["typeProperties"]["activities"][0]["typeProperties"]
+    assert inner == {"notebookId": "item-1", "workspaceId": "ws-guid"}
+
+
+def test_deploy_loose_folder_ignores_unsupported_files(_patch, tmp_path):
+    # Unsupported loose files are skipped, not errors; a folder with ONLY unsupported files still
+    # raises the no-items error.
+    fake = _patch(MultiDeployFabric())
+    root = tmp_path / "notebooks"
+    root.mkdir()
+    (root / "etl.ipynb").write_text(_NB_JSON, encoding="utf-8")
+    (root / "readme.md").write_text("# notes", encoding="utf-8")
+    assert _ws().deploy(str(root)) == {"etl": "item-1"}
+    junk = tmp_path / "junk"
+    junk.mkdir()
+    (junk / "data.csv").write_text("x", encoding="utf-8")
+    with pytest.raises(fr.RemoteRunError, match="no Fabric items"):
+        _ws().deploy(str(junk))
 
 
 def test_deploy_folder_unknown_type_raises(_patch, tmp_path):

--- a/tests/fabric_remote/test_workspace.py
+++ b/tests/fabric_remote/test_workspace.py
@@ -133,6 +133,34 @@ def test_create_warehouse_idempotent(_patch):
     assert fake.posts() == []                            # no create issued
 
 
+def test_create_lakehouse_folder_placement(_patch):
+    class FolderFabric(FakeFabric):
+        def __call__(self, method, url, **kw):
+            if url.endswith("/workspaces/ws-guid/folders"):
+                self.calls.append((method, url, kw.get("json_body")))
+                return FakeResp(200, {"value": []} if method == "GET" else {"id": "fld-1"})
+            return super().__call__(method, url, **kw)
+
+    fake = _patch(FolderFabric(existing=[], create=FakeResp(201, {"id": "lh-new"})))
+    assert _ws().create_lakehouse("bronze", folder="data") == "lh-new"
+    body = next(b for m, u, b in fake.calls if m == "POST" and u.endswith("/lakehouses"))
+    assert body["folderId"] == "fld-1"
+
+
+def test_create_warehouse_folder_placement(_patch):
+    class FolderWarehouseFabric(FakeWarehouseFabric):
+        def __call__(self, method, url, **kw):
+            if url.endswith("/workspaces/ws-guid/folders"):
+                self.calls.append((method, url, kw.get("json_body")))
+                return FakeResp(200, {"value": []} if method == "GET" else {"id": "fld-1"})
+            return super().__call__(method, url, **kw)
+
+    fake = _patch(FolderWarehouseFabric(existing=[], create=FakeResp(201, {"id": "wh-new"})))
+    assert _ws().create_warehouse("gold_dwh", folder="data") == "wh-new"
+    body = next(b for m, u, b in fake.calls if m == "POST" and u.endswith("/warehouses"))
+    assert body["folderId"] == "fld-1"
+
+
 def test_create_warehouse_lro_202(_patch):
     _patch(FakeWarehouseFabric(existing=[], create=FakeResp(202, headers={"Location": "u/lro"})))
     assert _ws().create_warehouse("gold_dwh") == "wh-lro"

--- a/tests/fabric_remote/test_workspace.py
+++ b/tests/fabric_remote/test_workspace.py
@@ -104,6 +104,40 @@ def test_lro_202_resolves_item_id(_patch):
     assert _ws().create_lakehouse("bronze") == "lh-lro"
 
 
+class FakeWarehouseFabric(FakeFabric):
+    """The warehouse counterpart of FakeFabric: serves the warehouses collection + create."""
+
+    def __call__(self, method, url, *, token, params=None, json_body=None, headers=None, timeout=60):
+        self.calls.append((method, url, json_body))
+        if method == "GET" and url.endswith("/workspaces"):
+            return FakeResp(200, {"value": [{"displayName": "Analytics", "id": "ws-guid"}]})
+        if method == "GET" and url.endswith("/workspaces/ws-guid/warehouses"):
+            return FakeResp(200, {"value": self.existing})
+        if method == "POST" and url.endswith("/workspaces/ws-guid/warehouses"):
+            return self.create
+        if method == "GET" and url == "u/lro":
+            return FakeResp(200, {"status": "Succeeded", "id": "wh-lro"})
+        raise AssertionError(f"unexpected call {method} {url}")
+
+
+def test_create_warehouse_new_returns_id(_patch):
+    fake = _patch(FakeWarehouseFabric(existing=[], create=FakeResp(201, {"id": "wh-new"})))
+    assert _ws().create_warehouse("gold_dwh") == "wh-new"
+    (_, _, body), = fake.posts()
+    assert body == {"displayName": "gold_dwh"}          # no creationPayload for a warehouse
+
+
+def test_create_warehouse_idempotent(_patch):
+    fake = _patch(FakeWarehouseFabric(existing=[{"displayName": "gold_dwh", "id": "wh-exist"}]))
+    assert _ws().create_warehouse("gold_dwh") == "wh-exist"
+    assert fake.posts() == []                            # no create issued
+
+
+def test_create_warehouse_lro_202(_patch):
+    _patch(FakeWarehouseFabric(existing=[], create=FakeResp(202, headers={"Location": "u/lro"})))
+    assert _ws().create_warehouse("gold_dwh") == "wh-lro"
+
+
 def test_list_lakehouses_shape(_patch):
     _patch(FakeFabric(existing=[{"displayName": "a", "id": "1"}, {"displayName": "b", "id": "2"}]))
     got = _ws().list_lakehouses()

--- a/tests/fabric_remote/test_workspace.py
+++ b/tests/fabric_remote/test_workspace.py
@@ -153,11 +153,12 @@ class DeployFabric:
     """Scripts the deploy sequence (list/create/delete + a Power BI refresh) and records every call."""
 
     def __init__(self, *, kind="notebooks", existing=None, refresh_status="Completed", lakehouses=None,
-                 update_resp=None):
+                 warehouses=None, update_resp=None):
         self.kind = kind                    # "notebooks" | "semanticModels" | "dataPipelines"
         self.existing = existing or []
         self.refresh_status = refresh_status
         self.lakehouses = lakehouses or []  # for the Direct Lake .bim repoint
+        self.warehouses = warehouses or []  # for the DirectQuery .bim repoint / sql_endpoint
         self.update_resp = update_resp      # overwrite-path updateDefinition response (default 200 sync)
         self.calls = []                     # (method, url, json_body)
 
@@ -167,6 +168,12 @@ class DeployFabric:
             return FakeResp(200, {"value": [{"displayName": "Analytics", "id": "ws-guid"}]})
         if method == "GET" and url.endswith("/workspaces/ws-guid/lakehouses"):
             return FakeResp(200, {"value": self.lakehouses})
+        if method == "GET" and url.endswith("/workspaces/ws-guid/warehouses"):
+            return FakeResp(200, {"value": self.warehouses})
+        for w in self.warehouses:
+            if method == "GET" and url.endswith(f"/workspaces/ws-guid/warehouses/{w['id']}"):
+                return FakeResp(200, {"id": w["id"], "properties": {
+                    "connectionString": "new-endpoint.datawarehouse.fabric.microsoft.com"}})
         if method == "GET" and url.endswith(f"/workspaces/ws-guid/{self.kind}"):
             return FakeResp(200, {"value": self.existing})
         if method == "POST" and url.endswith("/updateDefinition"):  # overwrite → update in place
@@ -221,11 +228,12 @@ def test_deploy_from_url(_patch, monkeypatch):
 
 
 def test_deploy_bim_creates_and_refreshes(_patch, monkeypatch, tmp_path):
-    fake = _patch(DeployFabric(kind="semanticModels"))
+    # A Direct Lake bim (OneLake reference) is created with the TMSL parts, then reframed.
+    fake = _patch(DeployFabric(kind="semanticModels",
+                               lakehouses=[{"displayName": "only", "id": "lh-only"}]))
     monkeypatch.setattr(wsmod, "get_powerbi_token", lambda: "PBI")
-    src = _write(tmp_path, "model.bim", json.dumps({"compatibilityLevel": 1702, "model": {}}))
+    src = _write(tmp_path, "model.bim", _directlake_bim())
     assert _ws().deploy(src) == "item-new"
-    # created the model with the TMSL parts, then fired a refresh and polled it
     parts = {p["path"] for p in fake.post_body("/workspaces/ws-guid/semanticModels")["definition"]["parts"]}
     assert parts == {"model.bim", "definition.pbism"}
     assert any(m == "POST" and u.endswith("/refreshes") for m, u, _ in fake.calls)
@@ -233,11 +241,21 @@ def test_deploy_bim_creates_and_refreshes(_patch, monkeypatch, tmp_path):
 
 
 def test_deploy_bim_failed_refresh_raises(_patch, monkeypatch, tmp_path):
-    _patch(DeployFabric(kind="semanticModels", refresh_status="Failed"))
+    _patch(DeployFabric(kind="semanticModels", refresh_status="Failed",
+                        lakehouses=[{"displayName": "only", "id": "lh-only"}]))
     monkeypatch.setattr(wsmod, "get_powerbi_token", lambda: "PBI")
-    src = _write(tmp_path, "model.bim", "{}")
+    src = _write(tmp_path, "model.bim", _directlake_bim())
     with pytest.raises(fr.RemoteRunError, match="refresh"):
         _ws().deploy(src)
+
+
+def test_deploy_non_directlake_bim_skips_refresh(_patch, monkeypatch, tmp_path):
+    # No OneLake reference → nothing to reframe: the model is created but never refreshed.
+    fake = _patch(DeployFabric(kind="semanticModels"))
+    monkeypatch.setattr(wsmod, "get_powerbi_token", lambda: "PBI")
+    src = _write(tmp_path, "model.bim", json.dumps({"compatibilityLevel": 1702, "model": {}}))
+    assert _ws().deploy(src) == "item-new"
+    assert not any(m == "POST" and u.endswith("/refreshes") for m, u, _ in fake.calls)
 
 
 # --- Direct Lake .bim repoint (OneLake workspace/lakehouse GUID rewrite) --------------------------
@@ -301,6 +319,99 @@ def test_deploy_lakehouse_arg_ignored_for_notebook(_patch, tmp_path):
     src = _write(tmp_path, "etl.ipynb", json.dumps({"nbformat": 4, "cells": [], "metadata": {}}))
     _ws().deploy(src, lakehouse="whatever")                 # ignored — no lakehouse lookup for a notebook
     assert not any(u.endswith("/lakehouses") for _, u, _ in fake.calls)
+
+
+# --- DirectQuery .bim repoint (Sql.Database server/db rewrite) + sql_endpoint ---------------------
+
+def _directquery_bim(db="tpch_dwh"):
+    """A minimal DirectQuery model.bim: partitions carry M expressions with
+    Sql.Database("<server>", "<db>") — quotes escaped in the raw JSON, as TMSL really is."""
+    expression = [
+        "let",
+        f'    Source = Sql.Database("old-endpoint.datawarehouse.fabric.microsoft.com", "{db}"),',
+        '    t = Source{[Schema="tpch",Item="dim_date"]}[Data]',
+        "in",
+        "    t",
+    ]
+    return json.dumps({"model": {"tables": [{"partitions": [
+        {"mode": "directQuery", "source": {"type": "m", "expression": expression}}]}]}})
+
+
+def _dq_fabric(_patch, monkeypatch, warehouses):
+    fake = _patch(DeployFabric(kind="semanticModels", warehouses=warehouses))
+    monkeypatch.setattr(wsmod, "get_powerbi_token", lambda: "PBI")
+    return fake
+
+
+def test_deploy_bim_repoints_to_named_warehouse(_patch, monkeypatch, tmp_path):
+    fake = _dq_fabric(_patch, monkeypatch, [{"displayName": "tpch_dwh", "id": "wh-1"},
+                                            {"displayName": "other_dwh", "id": "wh-2"}])
+    src = _write(tmp_path, "model.bim", _directquery_bim(db="stale_dwh"))
+    _ws().deploy(src, warehouse="tpch_dwh")
+    out = _deployed_bim(fake)
+    assert "old-endpoint.datawarehouse" not in out
+    assert "new-endpoint.datawarehouse.fabric.microsoft.com" in out   # server rewritten
+    assert "stale_dwh" not in out and "tpch_dwh" in out                # db rewritten to the named wh
+
+
+def test_deploy_bim_infers_warehouse_from_referenced_db(_patch, monkeypatch, tmp_path):
+    # The bim already references a warehouse that exists here → keep it, just fix the server.
+    fake = _dq_fabric(_patch, monkeypatch, [{"displayName": "tpch_dwh", "id": "wh-1"},
+                                            {"displayName": "other_dwh", "id": "wh-2"}])
+    src = _write(tmp_path, "model.bim", _directquery_bim(db="tpch_dwh"))
+    _ws().deploy(src)                                       # no warehouse= needed
+    out = _deployed_bim(fake)
+    assert "new-endpoint.datawarehouse.fabric.microsoft.com" in out
+    assert "tpch_dwh" in out
+
+
+def test_deploy_bim_infers_sole_warehouse(_patch, monkeypatch, tmp_path):
+    fake = _dq_fabric(_patch, monkeypatch, [{"displayName": "only_dwh", "id": "wh-1"}])
+    src = _write(tmp_path, "model.bim", _directquery_bim(db="stale_dwh"))
+    _ws().deploy(src)
+    out = _deployed_bim(fake)
+    assert "stale_dwh" not in out and "only_dwh" in out
+
+
+def test_deploy_bim_unknown_warehouse_raises(_patch, monkeypatch, tmp_path):
+    _dq_fabric(_patch, monkeypatch, [{"displayName": "tpch_dwh", "id": "wh-1"}])
+    src = _write(tmp_path, "model.bim", _directquery_bim())
+    with pytest.raises(fr.RemoteRunError, match="'typo_dwh' not found"):
+        _ws().deploy(src, warehouse="typo_dwh")
+
+
+def test_deploy_bim_warehouse_without_sql_ref_raises(_patch, monkeypatch, tmp_path):
+    # Explicit warehouse= on a model with no Sql.Database reference — nothing to point.
+    _dq_fabric(_patch, monkeypatch, [{"displayName": "tpch_dwh", "id": "wh-1"}])
+    src = _write(tmp_path, "model.bim", json.dumps({"model": {}}))
+    with pytest.raises(fr.RemoteRunError, match="no Sql.Database"):
+        _ws().deploy(src, warehouse="tpch_dwh")
+
+
+def test_sql_endpoint_from_warehouse(_patch):
+    _patch(DeployFabric(warehouses=[{"displayName": "tpch_dwh", "id": "wh-1"}]))
+    assert _ws().sql_endpoint() == "new-endpoint.datawarehouse.fabric.microsoft.com"
+    assert _ws().sql_endpoint("tpch_dwh") == "new-endpoint.datawarehouse.fabric.microsoft.com"
+
+
+def test_sql_endpoint_unknown_warehouse_raises(_patch):
+    _patch(DeployFabric(warehouses=[{"displayName": "tpch_dwh", "id": "wh-1"}]))
+    with pytest.raises(fr.RemoteRunError, match="'nope' not found.*tpch_dwh"):
+        _ws().sql_endpoint("nope")
+
+
+def test_sql_endpoint_lakehouse_fallback(_patch):
+    # No warehouse in the workspace → a lakehouse's SQL analytics endpoint serves the hostname.
+    class LhDetailFabric(DeployFabric):
+        def __call__(self, method, url, **kw):
+            if method == "GET" and url.endswith("/lakehouses/lh-1"):
+                self.calls.append((method, url, None))
+                return FakeResp(200, {"id": "lh-1", "properties": {"sqlEndpointProperties": {
+                    "connectionString": "new-endpoint.datawarehouse.fabric.microsoft.com"}}})
+            return super().__call__(method, url, **kw)
+
+    _patch(LhDetailFabric(lakehouses=[{"displayName": "bronze", "id": "lh-1"}]))
+    assert _ws().sql_endpoint() == "new-endpoint.datawarehouse.fabric.microsoft.com"
 
 
 # --- run -----------------------------------------------------------------------------------------
@@ -592,9 +703,10 @@ class MultiDeployFabric:
     """Scripts a whole-folder deploy: serves every item collection (+ lakehouses and the Power BI
     refresh), tracks creates so later name lookups see earlier items, and records every call."""
 
-    def __init__(self, *, existing=None, lakehouses=None, definitions=None, lro_defs=()):
+    def __init__(self, *, existing=None, lakehouses=None, warehouses=None, definitions=None, lro_defs=()):
         self.existing = existing or {}      # collection -> [{"displayName", "id"}]
         self.lakehouses = lakehouses if lakehouses is not None else [{"displayName": "bronze", "id": "lh-1"}]
+        self.warehouses = warehouses or []  # for the DirectQuery .bim repoint
         self.definitions = definitions or {}  # item id -> [part dicts] served by getDefinition
         self.lro_defs = set(lro_defs)         # item ids whose getDefinition goes the 202 route
         self._pending = None                  # parts awaiting the LRO /result fetch
@@ -619,6 +731,12 @@ class MultiDeployFabric:
             return FakeResp(200, {"value": [{"displayName": "Analytics", "id": "ws-guid"}]})
         if method == "GET" and url.endswith("/workspaces/ws-guid/lakehouses"):
             return FakeResp(200, {"value": self.lakehouses})
+        if method == "GET" and url.endswith("/workspaces/ws-guid/warehouses"):
+            return FakeResp(200, {"value": self.warehouses})
+        for w in self.warehouses:
+            if method == "GET" and url.endswith(f"/workspaces/ws-guid/warehouses/{w['id']}"):
+                return FakeResp(200, {"id": w["id"], "properties": {
+                    "connectionString": "new-endpoint.datawarehouse.fabric.microsoft.com"}})
         for coll in ("notebooks", "semanticModels", "dataPipelines", "variableLibraries"):
             if url.endswith(f"/workspaces/ws-guid/{coll}"):
                 if method == "GET":
@@ -768,6 +886,31 @@ def test_deploy_loose_folder_by_extension(_patch, monkeypatch, tmp_path):
     out = json.loads(_decoded_part(fake, "/workspaces/ws-guid/dataPipelines", "pipeline-content.json"))
     inner = out["properties"]["activities"][0]["typeProperties"]["activities"][0]["typeProperties"]
     assert inner == {"notebookId": "item-1", "workspaceId": "ws-guid"}
+
+
+def test_deploy_mixed_bim_folder_with_lakehouse_and_warehouse(_patch, monkeypatch, tmp_path):
+    # A folder holding a Direct Lake bim AND a DirectQuery bim, deployed with BOTH lakehouse= and
+    # warehouse=: each model gets only the rewrite that applies to it, nothing raises, and only
+    # the Direct Lake model is refreshed.
+    import base64 as b64
+    fake = _patch(MultiDeployFabric(warehouses=[{"displayName": "tpch_dwh", "id": "wh-1"}]))
+    monkeypatch.setattr(wsmod, "get_powerbi_token", lambda: "PBI")
+    root = tmp_path / "semantic_models"
+    root.mkdir()
+    (root / "dl.bim").write_text(_directlake_bim(), encoding="utf-8")
+    (root / "dq.bim").write_text(_directquery_bim(db="stale_dwh"), encoding="utf-8")
+    ids = _ws().deploy(str(root), lakehouse="bronze", warehouse="tpch_dwh", overwrite=True)
+    assert set(ids) == {"dl", "dq"}
+    deployed = {}
+    for m, u, body in fake.calls:
+        if m == "POST" and u.endswith("/workspaces/ws-guid/semanticModels"):
+            parts = {p["path"]: p for p in body["definition"]["parts"]}
+            deployed[body["displayName"]] = b64.b64decode(parts["model.bim"]["payload"]).decode()
+    assert "lh-1" in deployed["dl"] and "ws-guid" in deployed["dl"]         # DL: OneLake GUIDs
+    assert "new-endpoint.datawarehouse" in deployed["dq"]                    # DQ: server rewritten
+    assert "stale_dwh" not in deployed["dq"] and "tpch_dwh" in deployed["dq"]
+    refreshes = [u for m, u, _ in fake.calls if m == "POST" and u.endswith("/refreshes")]
+    assert len(refreshes) == 1                                               # DL only, DQ skipped
 
 
 def test_deploy_loose_folder_ignores_unsupported_files(_patch, tmp_path):


### PR DESCRIPTION
Extends the `duckrun.workspace(...)` control-plane handle so a repo of static artifacts can be deployed with one call per kind — no GUID surgery, no hand-rolled Fabric REST in the caller.

## What is new

**`create_warehouse(name, folder=None)`** — the warehouse sibling of `create_lakehouse`: idempotent, 202-aware, returns the item id.

**`sql_endpoint(warehouse=None)`** — the workspace TDS hostname (`….datawarehouse.fabric.microsoft.com`), read from a named warehouse, any warehouse, or a lakehouse SQL analytics endpoint as a fallback.

**`deploy(warehouse="name")`** — the DirectQuery counterpart of `lakehouse=`. Rewrites every `Sql.Database("<endpoint>", "<db>")` in a `.bim` to this workspace endpoint and the named warehouse. Inferred when the referenced database name matches a warehouse here, or the workspace has exactly one — mirroring the lakehouse resolution. Quotes are matched escaped or bare, since a bim is JSON.

**Refresh only for Direct Lake.** A deployed model was always refreshed; a DirectQuery-only model has nothing to reframe, so it is now skipped. Direct Lake is detected on the original bytes (a `directLake` partition mode or a OneLake reference) — detecting it after the repoint was a bug, since the repoint replaces the very ids the detector looked for.

**Plain folders.** A folder deploy with no `.platform` items falls back to the folder's loose `.ipynb` / `.bim` / `.json` files (top level, typed by extension, named by stem), so `ws.deploy("notebooks", overwrite=True)` ships a repo directory that was never laid out for git integration.

**Nested pipeline activities.** `notebook=` repointing walked only top-level activities, so a `TridentNotebook` inside a `ForEach` / `If` / `Until` / `Switch` was missed and the deploy raised "no TridentNotebook activity". It now recurses.

**Mixed folders.** `lakehouse=` / `warehouse=` are forwarded to each `.bim` only when the model carries that kind of reference, so a folder holding both Direct Lake and DirectQuery models deploys with both named.

**`folder=` on `create_lakehouse` / `create_warehouse`** — the same workspace folder placement `deploy(folder=...)` already had.

## Verification

82 tests in `tests/fabric_remote/test_workspace.py` (18 new), CI green.

Also exercised end to end against a real workspace: a benchmark repo now deploys its lakehouse, warehouse, three semantic models, six notebooks and a pipeline with one call each. The deployed DirectQuery model was downloaded back to confirm it carries the live SQL endpoint, and the Direct Lake model the live OneLake GUIDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
