### PR TITLE
perf: cross-schema discovery prefetch + concurrent delta_scan view binds (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Performance
+- **Read-only startup on a multi-schema OneLake project, round 2 (#16): ~28s → ~8s wall clock
+  (`dbt show` of one small model, ~80 tables over 8 schemas, residential connection; most of
+  the remainder is dbt parse + connection open).** 0.4.28 made the per-schema delta-rs opens
+  concurrent, but a multi-schema project still paid discovery schema-by-schema (dbt lists every
+  manifest schema serially on duckrun's single thread), and the `delta_scan` view registrations
+  stayed serial — each `CREATE VIEW` binds at creation, replaying the table's Delta log a second
+  time through DuckDB's delta extension (no metadata cache shared with delta-rs). Discovery now
+  prefetches the whole cache-population burst in one cross-schema pass
+  (`_relations_cache_for_schemas`): all listings, then ONE concurrent open pool for every
+  table's log, then ONE concurrent pool for the view binds (each worker on its own raw child
+  cursor — catalog and secrets are instance-global). The discovery pools also grew from 8 to 32
+  workers (the work is latency-bound, not CPU-bound). Per-schema semantics are unchanged:
+  same tombstone hiding, same persisted-docs re-apply, `OneLakeAccessError` still fails loud,
+  and the prefetch dies with the burst — a later `list_relations` call is never served stale.
+
 ## [0.4.29]
 
 ### Added

--- a/dbt/adapters/duckrun/engine.py
+++ b/dbt/adapters/duckrun/engine.py
@@ -747,6 +747,15 @@ def _delta_table(path: str, storage_options: Optional[Dict[str, str]]) -> DeltaT
     return DeltaTable(path)
 
 
+# Worker cap for the discovery pools (delta-rs log opens here, delta_scan view binds in the
+# adapter). The work is latency-bound, not CPU-bound — each unit is a handful of sequential
+# HTTPS round trips at 30-100ms+ from outside Azure — so the cap sets how many waves a
+# project-wide discovery pays: ~80 tables at 8 workers was 10 waves, at 32 it's 3 (#16).
+# 32 concurrent requests is still modest for OneLake; throttling (429) is retried inside
+# delta-rs / the DFS layer anyway.
+POOL_WORKERS = 32
+
+
 def open_delta_tables(targets):
     """One :class:`DeltaTable` (or None on failure) per ``(location, storage_options)`` in
     ``targets``, in order. Opens run concurrently: each is a Delta-log replay — several network
@@ -767,7 +776,7 @@ def open_delta_tables(targets):
 
     if len(targets) <= 1:
         return [_open(t) for t in targets]
-    with ThreadPoolExecutor(max_workers=min(8, len(targets))) as pool:
+    with ThreadPoolExecutor(max_workers=min(POOL_WORKERS, len(targets))) as pool:
         return list(pool.map(_open, targets))
 
 

--- a/dbt/adapters/duckrun/impl.py
+++ b/dbt/adapters/duckrun/impl.py
@@ -289,7 +289,7 @@ class DuckrunAdapter(DuckDBAdapter):
         from . import engine
         return engine.open_delta_tables(targets)
 
-    def _register_delta_view(self, relation, dt=None):
+    def _register_delta_view(self, relation, dt=None, cursor=None):
         """Create the ``delta_scan`` view for a discovered Delta relation on the live
         connection so read-only commands (``dbt test``, ``dbt show``, ``dbt docs``) that
         never materialize anything can still query the model.
@@ -298,8 +298,9 @@ class DuckrunAdapter(DuckDBAdapter):
         here too is harmless — the materialization's ``create or replace`` just supersedes it.
         But for a command that runs no models, this is the only place the physical view gets
         created from the Delta tables discovered on disk. ``dt`` is discovery's already-opened
-        handle, reused for the docs read. The caller has already created the schema (once, not
-        per relation).
+        handle, reused for the docs read. ``cursor`` lets a concurrent caller
+        (:meth:`_register_delta_views`) supply a per-worker cursor; default is the shared one.
+        The caller has already created the schema (once, not per relation).
         """
         root_path, _ = self.config.credentials.root_for(relation.database)
         if not root_path:
@@ -310,7 +311,8 @@ class DuckrunAdapter(DuckDBAdapter):
             + "/" + str(relation.identifier).strip('"')
         )
         try:
-            cursor = self._cursor()
+            if cursor is None:
+                cursor = self._cursor()
             loc_sql = location.replace("'", "''")  # escape quotes in the delta_scan path literal
             cursor.execute(
                 f"create or replace view {relation.render()} as "
@@ -325,11 +327,151 @@ class DuckrunAdapter(DuckDBAdapter):
             # debug so a systematic failure (e.g. a missing secret) is still diagnosable.
             logger.debug(f"duckrun: could not register delta_scan view for {location!r}: {exc}")
 
+    def _register_delta_views(self, pairs):
+        """Register the ``delta_scan`` views for ``[(relation, dt), …]``, concurrently.
+
+        ``CREATE VIEW … AS SELECT * FROM delta_scan(…)`` binds at creation — DuckDB's delta
+        extension replays the table's log over the network to resolve the view's types, and it
+        shares no metadata cache with the delta-rs opens that preceded it. Registered serially,
+        those binds were the residual startup tax of issue #16 after the delta-rs opens went
+        concurrent (several seconds per schema on OneLake from a high-latency connection).
+
+        Each worker gets its own raw child cursor of the shared DuckDB database — the catalog,
+        attached databases and (temporary) secrets are all instance-global, and concurrent DDL
+        on distinct view names doesn't conflict — so the wrapped shared cursor never crosses a
+        thread. Falls back to serial registration on the shared cursor when the raw connection
+        isn't reachable (remote/MotherDuck environments) or there's only one view to make.
+        Per-view failures stay best-effort inside :meth:`_register_delta_view`, so one broken
+        table can't sink the batch."""
+        from . import engine
+
+        if not pairs:
+            return
+        conn = None
+        try:
+            conn = getattr(DuckDBConnectionManager.env(), "conn", None)
+        except Exception:  # no environment yet (bare-adapter harness) → serial fallback
+            conn = None
+        if conn is None or len(pairs) == 1:
+            for rel, dt in pairs:
+                self._register_delta_view(rel, dt=dt)
+            return
+
+        from concurrent.futures import ThreadPoolExecutor
+
+        def _work(pair):
+            rel, dt = pair
+            cursor = conn.cursor()
+            try:
+                self._register_delta_view(rel, dt=dt, cursor=cursor)
+            finally:
+                try:
+                    cursor.close()
+                except Exception:  # pragma: no cover - close is best-effort
+                    pass
+
+        with ThreadPoolExecutor(max_workers=min(engine.POOL_WORKERS, len(pairs))) as pool:
+            list(pool.map(_work, pairs))
+
+    # ------------------------------------------------------------ bulk discovery prefetch
+    # dbt populates its relation cache at task start by listing EVERY manifest schema, and
+    # duckrun pins the run to one thread (Delta write safety), so those listings run serially.
+    # The per-schema work is remote-latency-bound (delta-rs log opens + delta_scan view binds),
+    # so paying it schema-by-schema left a multi-schema project with most of issue #16's tax
+    # even after the per-schema opens went concurrent. _relations_cache_for_schemas is the one
+    # place dbt announces the whole burst up front — so prefetch there: list every schema, then
+    # open ALL tables' logs in one cross-schema pool, then bind all views in another, and let
+    # each list_relations_without_caching call consume its precomputed slice. The prefetch dies
+    # with the burst (cleared in `finally`), so nothing is ever served stale to a later call.
+    _prefetched = None
+
+    @staticmethod
+    def _prefetch_key(schema_relation):
+        return (
+            str(schema_relation.database).strip('"').lower(),
+            str(schema_relation.schema).strip('"').lower(),
+        )
+
+    def _relations_cache_for_schemas(self, relation_configs, cache_schemas=None):
+        if not cache_schemas:
+            cache_schemas = self._get_cache_schemas(relation_configs)
+        try:
+            self._prefetched = self._prefetch_discovery(cache_schemas)
+        except remote.OneLakeAccessError:
+            raise  # a real access failure stays loud, exactly as in per-schema discovery
+        except Exception as exc:  # best-effort: fall back to the per-schema path unchanged
+            logger.debug(f"duckrun: bulk discovery prefetch failed, using per-schema path: {exc}")
+            self._prefetched = None
+        try:
+            super()._relations_cache_for_schemas(relation_configs, cache_schemas)
+        finally:
+            self._prefetched = None
+
+    def _prefetch_discovery(self, cache_schemas):
+        """Discover, tombstone-filter and view-register every schema's Delta tables in one
+        cross-schema pass; returns ``{(db, schema): [relations]}`` for
+        list_relations_without_caching to consume. Semantics per schema are identical to the
+        per-schema path — same listing, same tombstone contract, same best-effort registration —
+        only the batching differs."""
+        schemas, listed = {}, {}
+        for schema_relation in cache_schemas:
+            key = self._prefetch_key(schema_relation)
+            if key in schemas:  # two quotings of the same schema → one discovery
+                continue
+            schemas[key] = schema_relation
+            listed[key] = self._discover_delta_relations(schema_relation)
+
+        plan = []  # (key, relation, location, storage_options)
+        for key, discovered in listed.items():
+            if not discovered:
+                continue
+            root_path, so = self.config.credentials.root_for(schemas[key].database)
+            root_path = (root_path or "").rstrip("/")
+            for rel in discovered:
+                loc = (root_path + "/" + str(rel.schema).strip('"')
+                       + "/" + str(rel.identifier).strip('"'))
+                plan.append((key, rel, loc, so))
+
+        # ONE concurrent open pool across all schemas (tombstone check + persisted-docs read),
+        # then the tombstone filter — same contract as the per-schema path (see
+        # list_relations_without_caching for the fallback-probe rationale).
+        dts = self._open_delta_tables([(loc, so) for _, _, loc, so in plan])
+        cur = self._cursor()
+        live = {key: [] for key in listed}
+        for (key, rel, loc, so), dt in zip(plan, dts):
+            if dt is not None:
+                if delta_dml.is_dropped_dt(dt):
+                    continue
+            elif delta_dml.is_dropped(cur, loc, so):
+                continue
+            live[key].append((rel, dt))
+
+        # Schemas first (views need them; once per schema), then ONE concurrent bind pool
+        # across all schemas' views.
+        pairs = []
+        for key, rels in live.items():
+            if not rels:
+                continue
+            try:
+                self.create_schema(schemas[key])
+            except Exception as exc:  # best-effort, same contract as view registration
+                logger.debug(f"duckrun: could not create schema for {schemas[key]}: {exc}")
+            pairs.extend(rels)
+        self._register_delta_views(pairs)
+        return {key: [rel for rel, _ in rels] for key, rels in live.items()}
+
     def list_relations_without_caching(self, schema_relation):
         try:
             in_memory = list(super().list_relations_without_caching(schema_relation))
         except Exception:  # best-effort: a missing/empty in-memory schema still allows disk discovery
             in_memory = []
+
+        # Inside a cache-population burst everything (listing, tombstone filter, view
+        # registration) already happened in the cross-schema prefetch — just merge.
+        if self._prefetched is not None:
+            discovered = self._prefetched.get(self._prefetch_key(schema_relation))
+            if discovered is not None:
+                return self._merge_discovered(in_memory, discovered)
 
         discovered = self._discover_delta_relations(schema_relation)
         if not discovered:
@@ -371,17 +513,25 @@ class DuckrunAdapter(DuckDBAdapter):
             self.create_schema(schema_relation)
         except Exception as exc:  # best-effort, same contract as view registration below
             logger.debug(f"duckrun: could not create schema for {schema_relation}: {exc}")
-        for rel, dt in live:
-            self._register_delta_view(rel, dt=dt)
+        self._register_delta_views(live)
 
-        # A Delta table on disk is the source of truth, so disk discovery WINS over the
-        # in-memory catalog. This matters when several dbt runs share one process (dbt's test
-        # harness, a notebook, a long-lived runner): run 1 leaves a `delta_scan` *view* (type
-        # view) in the in-memory DuckDB, and if that stale view shadowed the disk table here,
-        # the relation would be reported as a view and is_incremental() would be false on run
-        # 2 — making the model clobber instead of merge. Reporting the discovered table (type
-        # table) instead makes a shared process behave exactly like a fresh one. Non-Delta
-        # relations (native `view`/`seed`) aren't discovered, so they pass through untouched.
+        return self._merge_discovered(in_memory, discovered)
+
+    @staticmethod
+    def _merge_discovered(in_memory, discovered):
+        """Merge disk-discovered relations over the in-memory catalog's.
+
+        A Delta table on disk is the source of truth, so disk discovery WINS over the
+        in-memory catalog. This matters when several dbt runs share one process (dbt's test
+        harness, a notebook, a long-lived runner): run 1 leaves a `delta_scan` *view* (type
+        view) in the in-memory DuckDB, and if that stale view shadowed the disk table here,
+        the relation would be reported as a view and is_incremental() would be false on run
+        2 — making the model clobber instead of merge. Reporting the discovered table (type
+        table) instead makes a shared process behave exactly like a fresh one. Non-Delta
+        relations (native `view`/`seed`) aren't discovered, so they pass through untouched.
+        """
+        if not discovered:
+            return in_memory
         discovered_names = {str(r.identifier).strip('"').lower() for r in discovered}
         merged = [
             r for r in in_memory

--- a/tests/adapter/test_discovery_dbt.py
+++ b/tests/adapter/test_discovery_dbt.py
@@ -121,6 +121,54 @@ def test_show_discovery_opens_concurrently_and_creates_schema_once(project, monk
     assert len(schema_creates) == 1
 
 
+def test_show_discovery_batches_across_schemas_and_binds_views_concurrently(project, monkeypatch):
+    """Issue #16, round 2: after the per-schema delta-rs opens went concurrent, a multi-schema
+    project still paid the tax schema-by-schema (dbt lists every manifest schema serially on
+    duckrun's single thread), and the delta_scan view registrations — whose CREATE binds by
+    replaying the Delta log a second time — stayed serial. Pin the batching fix through the real
+    command: ONE cross-schema open pool for the whole cache population, and every view bind off
+    the main thread (the concurrent registration pool)."""
+    proj, root = project
+    # A second model in a custom schema so the manifest spans two physical schemas.
+    (proj / "models" / "other.sql").write_text(
+        "{{ config(materialized='table', schema='x2') }}\nselect 42 as answer",
+        encoding="utf-8")
+    assert _dbt(proj, "run").success
+
+    # More tables in the default schema so the view-registration batch is a real pool (>1).
+    con = duckrun.connect(root, schema="main", read_only=False)
+    for i in range(2):
+        con.sql(f"create table t{i} as select {i} as id")
+
+    from dbt.adapters.duckrun import engine as dr_engine
+    from dbt.adapters.duckrun.impl import DuckrunAdapter
+
+    main_id = threading.get_ident()
+    open_batches, view_regs = [], []
+    real_open = dr_engine.open_delta_tables
+    real_reg = DuckrunAdapter._register_delta_view
+    monkeypatch.setattr(dr_engine, "open_delta_tables", lambda targets: (
+        open_batches.append([loc for loc, _ in targets]), real_open(targets))[1])
+    monkeypatch.setattr(DuckrunAdapter, "_register_delta_view", lambda self, relation, dt=None,
+                        cursor=None: (view_regs.append((str(relation), threading.get_ident())),
+                                      real_reg(self, relation, dt=dt, cursor=cursor))[1])
+
+    assert _dbt(proj, "show", "-s", "events").success
+
+    # The whole cache population opened its Delta logs in ONE cross-schema batch that spans
+    # both physical schemas — not one pool per schema.
+    non_empty = [b for b in open_batches if b]
+    assert len(non_empty) == 1
+    schemas_in_batch = {Path(loc).parent.name for loc in non_empty[0]}
+    assert schemas_in_batch == {"main", "main_x2"}
+    # Every discovered table's view got registered, and every bind ran off the main thread —
+    # serial binds on the shared cursor were the residual per-schema cost.
+    assert {name for name, _ in view_regs} >= {'"memory"."main"."events"',
+                                               '"memory"."main"."t0"', '"memory"."main"."t1"',
+                                               '"memory"."main_x2"."other"'}
+    assert all(tid != main_id for _, tid in view_regs)
+
+
 def test_docs_stats_panel_reads_the_delta_log(project):
     proj, root = project
     assert _dbt(proj, "run").success


### PR DESCRIPTION
## PR-Body

Follow-up to #16 — I dug into where the
remaining time goes and this PR addresses it. Numbers below are from a dummy project I created using Claude to simulate something similar as the one from work which was the source for my issue report (~80 tables over 8 schemas across two catalogs, residential connection, Windows 11, dbt-core 1.11.12).

### What was still slow after 0.4.28

Two things, both visible as silent gaps in a `--log-level-file debug` log (the work runs on
raw cursors, so it never shows up as SQL events):

1. **The per-schema work still runs schema-by-schema.** dbt populates its relation cache by
   listing every manifest schema, serially on duckrun's single thread. The 0.4.28 pool makes
   the opens concurrent *within* one schema, but an 8-schema project still pays 8 sequential
   rounds of (REST listing → open pool → view loop).
2. **The `delta_scan` view registrations are serial, and each one replays the log again.**
   `CREATE OR REPLACE VIEW … AS SELECT * FROM delta_scan(…)` binds at creation — DuckDB's
   delta extension does a full log read to resolve the view's types, through its own HTTP
   stack with no metadata cache shared with delta-rs. Verified: `CREATE VIEW` over a
   nonexistent path fails immediately with `DeltaKernel InvalidTableLocationError`, so the
   bind provably happens at CREATE. In my log this loop was the bigger half of each schema's
   cost (up to ~25s for the elementary schema in the 90s run from the issue).

Gap profile of a baseline run (0.4.29, 27.9s total): per schema ~1–2s in the open pool, then
~3–4.5s silent in the serial view loop.

### What this PR changes

- **One cross-schema prefetch per cache population.** `_relations_cache_for_schemas` is the
  one place dbt announces the whole burst up front, so discovery now runs there: list every
  schema, then open **all** tables' logs in ONE pool, then bind **all** views in ONE pool,
  and let each `list_relations_without_caching` call consume its precomputed slice. The
  prefetch is cleared in `finally`, so nothing is ever served stale to a later call; direct
  `list_relations` calls outside a burst keep the previous per-schema path (now with
  concurrent view binds too), and a prefetch failure falls back to that path
  (`OneLakeAccessError` still fails loud).
- **Concurrent view binds on raw child cursors.** Each worker gets its own
  `conn.cursor()` of the shared DuckDB database — catalog, attached databases and
  (temporary) secrets are instance-global, and concurrent DDL on distinct view names doesn't
  conflict (tested). The wrapped shared cursor never crosses a thread.
- **Pool workers 8 → 32** (`engine.POOL_WORKERS`, shared by the open pool and the bind
  pool). The work is latency-bound — a handful of sequential HTTPS round trips per table at
  30–100ms+ from outside Azure — so the cap sets how many waves a project-wide discovery
  pays: ~80 tables at 8 workers was 10 waves, at 32 it's 3.

Semantics are unchanged: same tombstone hiding (drop-tombstones never surface, including the
DuckDB-side fallback probe when delta-rs can't open a table), same persisted-docs re-apply
(so `dbt docs generate` still shows them), same best-effort error handling, discovered Delta
tables still reported table-typed so `is_incremental()` survives fresh processes.

### Numbers

`dbt show -s <one small model>` on the project above, warm parse, 2nd run of each variant:

| | wall clock | adapter discovery share |
|---|---|---|
| duckrun 0.4.29 | 27.9s | ~20s (gaps across 8 schemas) |
| this PR | **8.3s** | **~2s** (one batch) |

The remaining ~6s is dbt parse + connection open, not discovery. Inside a Fabric notebook the
effect will be smaller (low latency to OneLake), but the round-trip count drops the same way.

### Tests

- New: `test_show_discovery_batches_across_schemas_and_binds_views_concurrently` — a real
  `dbt show` over two physical schemas asserts ONE cross-schema open batch and every view
  bind off the main thread.
- The existing #16 test (opens concurrent, schema created once) and the tombstone/docs tests
  pass unchanged on the new path.
- Full `tests/adapter` + `tests/connection_api`: 456 passed, 1 skipped (live OneLake test
  without token).

