### PR TITLE
fix: debug-session correctness sweep + fail-loud glob discovery + upstream alias precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **`p.sql()` can now read a `ref()` to a view-materialized model on a cold session** (#29
+  follow-up). An inline compile's node is out of the manifest before anything runs — dbt removes it
+  on success, the session's own cleanup on failure — so view-ancestor binding, which started from
+  the node id, found nothing to register and the ref died in the lazy bind (`Catalog Error`,
+  because a view model never wrote a Delta table for it to find). `show()` of the same model
+  worked, which made the failure look like the user's SQL. The compile now records the inline
+  node's direct parents and binding walks from them.
+- **A same-named model in an installed package no longer aborts `show()`** (#29 follow-up). View
+  ancestors were compiled by bare name, and `--select v_boosted` matches every node of that name —
+  so a package shipping any model with the same name failed a `show()` the caller HAD named
+  unambiguously, with "narrow the selector" advice about a selector they never wrote. Ancestors now
+  compile by full dotted fqn (`fqn:pkg.….model`), with the returned node id checked.
+- **CTE slicing now walks the WITH list's structure instead of hunting for a `SELECT` keyword**
+  (#29 follow-up). A main query of `(select …) union all (select …)` has no top-level `SELECT` at
+  all, so `ctes()` reported `[]` and `cte()` claimed the model "has no CTEs" — false for a model
+  that plainly has them; and DuckDB's FROM-first syntax (`from base select …`) put the hunted
+  keyword mid-query, so the last CTE's text silently swallowed `from base` and the splice ran two
+  body clauses. The splitter now hands over to the main query at the token that follows the last
+  CTE body, whatever the query starts with. A WITH list the splitter still cannot take apart is now
+  said out loud instead of being reported as "no CTEs", and `cte()` matches names
+  case-insensitively, as DuckDB itself resolves identifiers.
+- **The read-only debug cursor refuses `COPY … TO` and `EXPORT DATABASE`.** Both classify as
+  passthrough — native DuckDB, no delta_rs route — but they write files wherever the session's live
+  store credentials reach, including the lakehouse, and no read-only `delta_scan` view sits
+  downstream to refuse them. `COPY <table> FROM …` (loading into a scratch table) still works.
+- **A store error during glob discovery fails the run instead of emptying the schema.** On
+  local / `az://` / `s3://` / `gs://` roots, `list_delta_tables_via_glob` caught every exception
+  and returned `[]` — but DuckDB's `glob` already yields zero rows (no error) for a missing schema
+  dir, so the only things the catch ever converted were real failures: a missing/expired secret, a
+  transport error, an absent bucket. An empty listing makes every table vanish from dbt's relation
+  cache, flips `is_incremental()` off, and the next run full-refreshes over the table — the exact
+  silent clobber OneLake discovery already fails loud on. Glob stores now share that contract.
+- **`partitioned_by` / `sorted_by` follow upstream's precedence exactly** (dbt-duckdb 1.11
+  follow-up). The aliases were resolved with a truthiness `or`, so a canonical empty list —
+  `partitioned_by: []`, an explicit "no partitioning" — silently fell through to a legacy
+  `partition_by` and the model got partitioned anyway. Upstream keeps the canonical value unless it
+  is none or `''`, and rejects an empty column list outright ("must contain at least one column");
+  duckrun now does both, in `_delta_core.sql` and `seed.sql`.
 - **Column-mapped tables no longer report their statistics under generated GUIDs** (#32). A Delta
   table with `delta.columnMapping.mode` on keys its parquet footer and its `add.stats` by a physical
   `col-<guid>` name, so `get_stats(detailed=True)` returned per-column size / encoding / dictionary

--- a/dbt/adapters/duckrun/delta_dml.py
+++ b/dbt/adapters/duckrun/delta_dml.py
@@ -849,9 +849,68 @@ def _split_top_level_commas(s: str) -> List[str]:
 
 # ── CTE slicing, for the dbt debug session (duckrun.dbt_project, issue #29) ────────────────────
 _CTE_LEADING_WITH = re.compile(r"\s*with\s+(?:recursive\s+)?", re.I)
-_CTE_COMMA = re.compile(r",")
+_CTE_AS_KW = re.compile(r"as\b", re.I)
 # `name [(cols)] AS …` — the name is a bare identifier or a double-quoted one ("" escapes a quote).
 _CTE_NAME = re.compile(r'\s*("(?:[^"]|"")+"|[A-Za-z_]\w*)')
+
+
+def has_leading_with(sql: str) -> bool:
+    """True when the statement opens with ``WITH`` (comment- and whitespace-tolerant) — i.e. it HAS
+    a CTE list, even if :func:`split_cte_list` declined to take it apart."""
+    return bool(_CTE_LEADING_WITH.match(_blank_string_literals(_strip_comments(sql, keep_length=True))))
+
+
+def _cte_list_bounds(mask: str, after: int):
+    """``(comma_positions, main_start)`` for the CTE list beginning at ``after`` in ``mask``.
+
+    Walks the list STRUCTURALLY instead of hunting for a ``SELECT`` keyword: after each CTE body's
+    closing ``)`` at depth 0, the next token is either ``,`` (another CTE), ``AS`` (the ``)`` closed
+    a column list / ``USING KEY`` list, the body is still to come), or the main query — whatever it
+    starts with. A keyword hunt cannot get that right: a main query of ``(select …) union all
+    (select …)`` has no top-level ``SELECT`` at all, and DuckDB's ``FROM x SELECT y`` puts its
+    top-level ``SELECT`` in the middle, so hunting either declines a sliceable model or hands the
+    tail CTE half the main query. ``main_start`` is ``-1`` when the list never hands over
+    (malformed / truncated input)."""
+    commas: List[int] = []
+    depth, quote, closed = 0, None, False
+    i, n = after, len(mask)
+    while i < n:
+        ch = mask[i]
+        if quote:
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            continue
+        if ch == "$":
+            de = _dollar_quote_end(mask, i)
+            if de is not None:
+                i = de
+                continue
+        if depth == 0:
+            if ch == ",":
+                commas.append(i)
+                closed = False
+                i += 1
+                continue
+            if closed and not ch.isspace():
+                at_boundary = not (i and (mask[i - 1].isalnum() or mask[i - 1] == "_"))
+                if at_boundary and _CTE_AS_KW.match(mask, i):
+                    closed = False  # `name (cols) AS (…)` — that `)` ended the column list
+                    i += 2
+                    continue
+                return commas, i    # the CTE list handed over: the main query starts here
+        if ch in "([":
+            depth += 1
+        elif ch in ")]":
+            depth -= 1
+            if depth == 0 and ch == ")":
+                closed = True
+        i += 1
+    return commas, -1
 
 
 def split_cte_list(sql: str):
@@ -875,13 +934,10 @@ def split_cte_list(sql: str):
     if not lead:
         return "", [], sql
     after = lead.end()
-    # The first top-level SELECT after the WITH list is the main one: every CTE's own SELECT sits
-    # inside parentheses, which the scanner steps over.
-    offset = _find_top_level(mask[after:], _SELECT_KW)
-    if offset < 0:
+    commas, end = _cte_list_bounds(mask, after)
+    if end < 0:
         return "", [], sql
-    end = after + offset
-    bounds = [after] + [after + c + 1 for c in _find_all_top_level(mask[after:end], _CTE_COMMA)]
+    bounds = [after] + [c + 1 for c in commas]
     parts = []
     for start, stop in zip(bounds, bounds[1:] + [end]):
         text = sql[start:stop].rstrip().rstrip(",")

--- a/dbt/adapters/duckrun/environment.py
+++ b/dbt/adapters/duckrun/environment.py
@@ -54,6 +54,15 @@ class DuckrunReadOnlyError(RuntimeError):
     """A write was attempted on a read-only duckrun cursor (``duckrun.dbt_project``)."""
 
 
+# Statements that write OUTSIDE the DuckDB catalog — files, or another attached database — from a
+# session holding live store credentials. `classify` calls these passthrough (correctly: they are
+# native DuckDB, no delta_rs route), so the read-only cursor must catch them itself: unlike a
+# catalog write there is no delta_scan view downstream to refuse them.
+_COPY_HEAD = re.compile(r"\s*copy\b", re.I)
+_COPY_TO_KW = re.compile(r"\bto\b", re.I)   # leading \b: `manifesto` must not read as ... TO
+_EXPORT_HEAD = re.compile(r"\s*export\s+database\b", re.I)
+
+
 class _DeltaBindCursor(DuckDBCursorWrapper):
     """The cursor machinery both of duckrun's cursor kinds need: the OneLake token refresh every
     statement depends on, and the lazy bind that resolves a duckrun model to its Delta location
@@ -271,24 +280,42 @@ class DuckrunDebugCursor(_DeltaBindCursor):
     def _reject_write(self, sql) -> None:
         """Raise for a statement whose FORM writes.
 
-        This is the error MESSAGE, not the safety — the safety is that this class has no delta_rs
-        route at all. Without it a write still fails, but as DuckDB's bare "cannot ... a view",
-        which never explains that the view is a view because duckrun made it one. Classified by the
-        very ``delta_dml.classify`` the write path routes on, so "what counts as a write" can't
-        drift between the two. ``CREATE TEMP TABLE`` / ``CREATE VIEW`` classify as passthrough and
-        stay allowed: scratch objects are how you actually debug.
+        For a Delta write this is the error MESSAGE, not the safety — the safety is that this class
+        has no delta_rs route at all. Without it a write still fails, but as DuckDB's bare "cannot
+        ... a view", which never explains that the view is a view because duckrun made it one.
+        Classified by the very ``delta_dml.classify`` the write path routes on, so "what counts as
+        a write" can't drift between the two. ``CREATE TEMP TABLE`` / ``CREATE VIEW`` classify as
+        passthrough and stay allowed: scratch objects are how you actually debug.
+
+        For ``COPY ... TO`` / ``COPY FROM DATABASE ... TO`` / ``EXPORT DATABASE`` the check IS the
+        safety: they classify passthrough (native DuckDB, no delta_rs), but they write files —
+        anywhere the session's live store credentials reach, including the lakehouse — and there is
+        no read-only view downstream to refuse them. ``COPY <table> FROM ...`` (a load into a
+        scratch table) keeps working; a top-level ``TO`` is what marks the writing direction.
 
         Single-statement by construction (classify takes one statement). A multi-statement script
         whose first statement reads slips past the message — and then fails anyway, on the view, in
         DuckDB. Degraded message, never degraded safety."""
-        if delta_dml.classify(sql) == "passthrough":
-            return
         first = " ".join(str(sql).split())[:120]
-        raise DuckrunReadOnlyError(
-            f"read-only debug session: this statement writes.\n    {first}\n"
-            "duckrun models are read-only delta_scan views here, so nothing in this session can "
-            "reach delta_rs. To write, use `dbt run` or duckrun.connect(..., read_only=False)."
-        )
+        if delta_dml.classify(sql) != "passthrough":
+            raise DuckrunReadOnlyError(
+                f"read-only debug session: this statement writes.\n    {first}\n"
+                "duckrun models are read-only delta_scan views here, so nothing in this session "
+                "can reach delta_rs. To write, use `dbt run` or "
+                "duckrun.connect(..., read_only=False)."
+            )
+        mask = delta_dml._blank_string_literals(
+            delta_dml._strip_comments(str(sql), keep_length=True))
+        if _EXPORT_HEAD.match(mask) or (
+                _COPY_HEAD.match(mask)
+                and delta_dml._find_top_level(mask, _COPY_TO_KW) >= 0):
+            raise DuckrunReadOnlyError(
+                f"read-only debug session: this statement writes files.\n    {first}\n"
+                "COPY ... TO / EXPORT DATABASE write with this session's store credentials, so a "
+                "read-only session refuses them. To export, materialize through "
+                "duckrun.connect(..., read_only=False), or fetch the relation and write it "
+                "client-side."
+            )
 
 
 class DuckrunEnvironment(LocalEnvironment):

--- a/dbt/adapters/duckrun/remote.py
+++ b/dbt/adapters/duckrun/remote.py
@@ -199,15 +199,17 @@ def list_delta_tables_via_glob(cursor, root_path: str, schema: str) -> List[str]
     the caller is responsible for having minted whatever store secret the glob needs first
     (az://, s3, gcs). OneLake (``abfss://``) can't be globbed; use ``list_delta_tables`` there.
 
-    Returns ``[]`` if nothing matches or the glob errors (e.g. the schema dir doesn't exist yet)."""
+    Returns ``[]`` when nothing matches — which is what an absent schema dir produces: DuckDB's
+    ``glob`` yields zero rows for a missing path, no error. Raises on everything else (missing
+    secret, transport failure, absent bucket): those are stores we genuinely cannot see right now,
+    and degrading them to an empty schema makes every table vanish from the relation cache, flips
+    ``is_incremental()`` off, and full-refreshes over the table — the same silent clobber
+    ``list_delta_tables`` fails loud on for OneLake."""
     base = root_path.rstrip("/") + "/" + str(schema).strip('"')
     # `*` matches one path segment (the table dir); every committed Delta table has at least one
     # commit json (00..0.json is unreliable after cleanup_metadata()).
     pattern = (base + "/*/_delta_log/*.json").replace("'", "''")
-    try:
-        rows = cursor.execute(f"SELECT DISTINCT file FROM glob('{pattern}')").fetchall()
-    except Exception:  # missing dir / unsupported store -> no tables (caller may log)
-        return []
+    rows = cursor.execute(f"SELECT DISTINCT file FROM glob('{pattern}')").fetchall()
 
     marker = "/_delta_log/"
     names: List[str] = []

--- a/dbt/include/duckrun/macros/materializations/_delta_core.sql
+++ b/dbt/include/duckrun/macros/materializations/_delta_core.sql
@@ -195,9 +195,24 @@
   {%- set _batch_end = _batch.get('event_time_end').strftime('%Y-%m-%d %H:%M:%S') if _batch and _batch.get('event_time_end') else none -%}
 
   {#-- 2. Hand off to the delta-write plugin (store -> write_deltalake / merge).
-       partition/sort: dbt-duckdb 1.11 canonicalized the spellings as partitioned_by/sorted_by
-       (aliasing our spellings both ways); accept its spellings with the same precedence,
-       canonical name first. --#}
+       partition/sort: dbt-duckdb 1.11 canonicalized the spellings as partitioned_by/sorted_by.
+       Upstream precedence, verbatim: the canonical name wins unless it is none or '' — an empty
+       LIST is kept, not quietly rescued by a legacy partition_by/sort_by, and (as upstream) an
+       empty column list is a hard error rather than a silently unpartitioned/unsorted table. --#}
+  {%- set _partition_by = config.get('partitioned_by') -%}
+  {%- if _partition_by is none or _partition_by == '' -%}
+    {%- set _partition_by = config.get('partition_by') -%}
+  {%- endif -%}
+  {%- if _partition_by is not none and _partition_by is not string and _partition_by | length == 0 -%}
+    {% do exceptions.raise_compiler_error("partitioned_by/partition_by must contain at least one column") %}
+  {%- endif -%}
+  {%- set _sort_by = config.get('sorted_by') -%}
+  {%- if _sort_by is none or _sort_by == '' -%}
+    {%- set _sort_by = config.get('sort_by') -%}
+  {%- endif -%}
+  {%- if _sort_by is not none and _sort_by is not string and _sort_by | length == 0 -%}
+    {% do exceptions.raise_compiler_error("sorted_by/sort_by must contain at least one column") %}
+  {%- endif -%}
   {%- set delta_config = {
       'incremental': is_incremental,
       'incremental_strategy': config.get('incremental_strategy'),
@@ -207,8 +222,8 @@
       'not_null_columns': not_null_columns,
       'full_refresh': should_full_refresh(),
       'unique_key': config.get('unique_key'),
-      'partition_by': config.get('partitioned_by') or config.get('partition_by'),
-      'sort_by': config.get('sorted_by') or config.get('sort_by'),
+      'partition_by': _partition_by,
+      'sort_by': _sort_by,
       'max_row_group_size': config.get('max_row_group_size'),
       'target_file_size_mb': config.get('target_file_size_mb'),
       'merge_schema': config.get('merge_schema', false),

--- a/dbt/include/duckrun/macros/materializations/seed.sql
+++ b/dbt/include/duckrun/macros/materializations/seed.sql
@@ -64,12 +64,20 @@
   {%- set columns = adapter.get_columns_in_relation(tmp_relation) -%}
 
   {#-- 2. Hand the staged rows to the delta-write plugin: a plain overwrite, exactly like `table`.
-        partition: dbt-duckdb 1.11's canonical spelling accepted too, same precedence as _delta_core. --#}
+        partition: dbt-duckdb 1.11's canonical spelling accepted too, upstream precedence exactly
+        as _delta_core (canonical wins unless none or ''; an empty column list is an error). --#}
+  {%- set _partition_by = config.get('partitioned_by') -%}
+  {%- if _partition_by is none or _partition_by == '' -%}
+    {%- set _partition_by = config.get('partition_by') -%}
+  {%- endif -%}
+  {%- if _partition_by is not none and _partition_by is not string and _partition_by | length == 0 -%}
+    {% do exceptions.raise_compiler_error("partitioned_by/partition_by must contain at least one column") %}
+  {%- endif -%}
   {%- set delta_config = {
       'incremental': false,
       'full_refresh': should_full_refresh(),
       'storage_options': config.get('storage_options'),
-      'partition_by': config.get('partitioned_by') or config.get('partition_by'),
+      'partition_by': _partition_by,
   } -%}
   {% do adapter.store_relation('duckrun', tmp_relation, columns, location, 'delta', delta_config) %}
 

--- a/docs/dbt-debug.md
+++ b/docs/dbt-debug.md
@@ -165,6 +165,12 @@ p.sql("create or replace view v_check as select customer, count(*) from candidat
 They live only in the in-memory DuckDB catalog and never reach the lakehouse. duckrun has no `view`
 materialization at all — the only things it writes are Delta tables, through delta_rs.
 
+File exports are refused too. `COPY ... TO` and `EXPORT DATABASE` never touch delta_rs, but they
+write files wherever the session's store credentials reach — including the lakehouse — so a
+read-only session rejects them the same way. `COPY <table> FROM ...` (loading a file *into* a
+scratch table) keeps working. To export a result, fetch the relation and write it client-side, or
+use `duckrun.connect(..., read_only=False)`.
+
 One exception, and it is dbt's rather than duckrun's: a `create` statement that refs an **ephemeral**
 model cannot work. dbt injects an ephemeral model by prepending `with __dbt__cte__<name> as (...)`
 to the query, and a `WITH` clause only parses in front of a `SELECT`. Build the relation first

--- a/duckrun/dbt_debug.py
+++ b/duckrun/dbt_debug.py
@@ -88,9 +88,9 @@ class CompileResult:
     here instead, on ``DbtProject.last_compile``.
     """
 
-    __slots__ = ("model", "node_id", "sql", "full_refresh", "cte", "incremental")
+    __slots__ = ("model", "node_id", "sql", "full_refresh", "cte", "incremental", "parents")
 
-    def __init__(self, model, node_id, sql, full_refresh, cte=None, incremental=None):
+    def __init__(self, model, node_id, sql, full_refresh, cte=None, incremental=None, parents=()):
         self.model = model
         self.node_id = node_id
         #: The SQL that actually RAN — for a ``cte()`` call that is the sliced query, not the
@@ -103,6 +103,11 @@ class CompileResult:
         #: Which ``is_incremental()`` branch this SQL came from — True or False — or None when the
         #: model does not branch on it at all and there is therefore nothing to be ambiguous about.
         self.incremental = incremental
+        #: The compiled node's direct manifest parents. For an inline ``sql()`` compile the node
+        #: itself is gone from the manifest by the time anything runs (dbt removes it on success,
+        #: :meth:`DbtProject._drop_inline_node` on failure), so these are what view-ancestor
+        #: binding starts from.
+        self.parents = tuple(parents or ())
 
     def __repr__(self):
         extra = f", cte={self.cte!r}" if self.cte else ""
@@ -183,9 +188,16 @@ class DbtProject:
         It hides them from the LISTING only. They are genuinely in the compiled SQL, ``cte()``
         still takes their names, and slicing at one is often exactly right: it shows a staging
         model in the context of the model that consumes it."""
-        from dbt.adapters.duckrun.delta_dml import split_cte_list
+        from dbt.adapters.duckrun.delta_dml import has_leading_with, split_cte_list
         sql = self.compiled(model, incremental=incremental)
-        names = [name for name, _ in split_cte_list(sql)[1]]
+        parts = split_cte_list(sql)[1]
+        if not parts and has_leading_with(sql):
+            # The compiled SQL opens with WITH but the splitter declined to take it apart.
+            # Reporting [] here would claim the model has no CTEs, which is false.
+            raise DbtProjectError(
+                f"{model!r} has a WITH list this splitter cannot take apart — read it with "
+                f"compiled() instead.")
+        names = [name for name, _ in parts]
         return names if ephemeral else [n for n in names if not n.startswith(_EPHEMERAL_CTE)]
 
     def cte(self, model, name, incremental=None):
@@ -208,16 +220,25 @@ class DbtProject:
 
     @staticmethod
     def _slice_to_cte(sql, name, model) -> str:
-        from dbt.adapters.duckrun.delta_dml import split_cte_list
+        from dbt.adapters.duckrun.delta_dml import has_leading_with, split_cte_list
 
         head, parts, _ = split_cte_list(sql)
         names = [n for n, _ in parts]
         if not names:
+            if has_leading_with(sql):
+                raise DbtProjectError(
+                    f"{model!r} has a WITH list this splitter cannot take apart — read it with "
+                    f"compiled() instead.")
             raise DbtProjectError(
                 f"{model!r} has no CTEs — its compiled SQL is a single SELECT. Use show() instead.")
         if name not in names:
-            raise DbtProjectError(
-                f"{model!r} has no CTE {name!r}. It has: {', '.join(names)}")
+            # DuckDB resolves unquoted identifiers case-insensitively, so `cte(m, 'totals')` must
+            # find a CTE spelled TOTALS. Exact match first; fold only when it is unambiguous.
+            folded = [n for n in names if n.lower() == str(name).lower()]
+            if len(folded) != 1:
+                raise DbtProjectError(
+                    f"{model!r} has no CTE {name!r}. It has: {', '.join(names)}")
+            name = folded[0]
         kept = parts[:names.index(name) + 1]
         # Later CTEs are dropped rather than left in place. DuckDB would not evaluate them anyway —
         # it does not even bind an unused CTE — so this is for what you READ back in
@@ -460,13 +481,13 @@ class DbtProject:
         key = (selector, inline, full_refresh)
         if key not in self._compiled:
             self._compiled[key] = self._run_compile(selector, inline, full_refresh)
-        name, node_id, sql, branches = self._compiled[key]
+        name, node_id, sql, branches, parents = self._compiled[key]
         incremental = self._which_branch(selector, inline, full_refresh, sql, branches)
         # A fresh CompileResult per call: cte() rewrites .sql on it, and that must not reach back
         # into the cache and corrupt the next caller's answer.
         self.last_compile = CompileResult(
             model=name, node_id=node_id, sql=sql, full_refresh=full_refresh,
-            incremental=incremental)
+            incremental=incremental, parents=parents)
         if branches and not full_refresh:
             self._report_branch(self.last_compile)
         return self.last_compile
@@ -592,7 +613,11 @@ class DbtProject:
         node_id = getattr(node, "unique_id", None)
         if node_id is not None:
             self._compiled_nodes.add(node_id)   # so a repeat compile of it re-injects; see above
-        return (getattr(node, "name", selector), node_id, node.compiled_code, branches)
+        # The node's direct parents, taken NOW: for an inline compile the node object outlives the
+        # manifest entry (dbt removes it on success, _drop_inline_node on failure), and these ids
+        # are all view-ancestor binding has left to start from.
+        parents = tuple(getattr(getattr(node, "depends_on", None), "nodes", None) or ())
+        return (getattr(node, "name", selector), node_id, node.compiled_code, branches, parents)
 
     # ── the connection ─────────────────────────────────────────────────────────────────────────
 
@@ -628,7 +653,7 @@ class DbtProject:
             return env
         return DuckrunEnvironment(creds)
 
-    def _bind_view_ancestors(self, node_id):
+    def _bind_view_ancestors(self, node_id, parents=()):
         """Register every ``view``-materialized model the compiled node reads — as a VIEW — before
         running it. By default, on every call; never in reaction to an error.
 
@@ -652,7 +677,13 @@ class DbtProject:
         ancestor's ``_delta_log`` for models you never open.
 
         A VIEW, never a materialization: ``create or replace view``, so the relation stays lazy and
-        ``.filter(...)`` still pushes through it into the ``delta_scan`` underneath."""
+        ``.filter(...)`` still pushes through it into the ``delta_scan`` underneath.
+
+        ``parents`` is the fallback root set for a node the manifest no longer holds — an inline
+        ``sql()`` compile, whose node dbt removes on success and :meth:`_drop_inline_node` on
+        failure. Walking from its recorded parents is the same traversal one level down; without it
+        an inline ``{{ ref() }}`` to a view model found nothing to register and died in the lazy
+        bind, which only knows Delta tables (a view model never wrote one)."""
         nodes = getattr(self._manifest, "nodes", None) or {}
         seen = set()
 
@@ -670,7 +701,11 @@ class DbtProject:
             if nid != node_id and _materialization(node) == "view":
                 self._create_view(node)
 
-        walk(node_id)
+        if node_id in nodes or not parents:
+            walk(node_id)
+        else:
+            for parent in parents:
+                walk(parent)
 
     def _create_view(self, node):
         """``create or replace view`` for one view-materialized model, at the name dbt renders for
@@ -679,9 +714,20 @@ class DbtProject:
         relation = getattr(node, "relation_name", None)
         if not relation or relation in self._bound_views:
             return
-        key = (node.name, None, False)
+        # By full fqn, never by bare name: `--select v_boosted` selects EVERY node of that name, so
+        # one same-named model in an installed package aborted show() on a dependency the caller
+        # never typed ("matched 2 nodes ... narrow the selector" — about a selector they never
+        # wrote). The dotted fqn is unique per node; the id check makes a selector-semantics drift
+        # loud instead of quietly compiling somebody else's SQL into this view.
+        selector = "fqn:" + ".".join(str(part) for part in (getattr(node, "fqn", None) or [node.name]))
+        key = (selector, None, False)
         if key not in self._compiled:
-            self._compiled[key] = self._run_compile(node.name, None, False)
+            self._compiled[key] = self._run_compile(selector, None, False)
+        compiled_id = self._compiled[key][1]
+        if compiled_id != getattr(node, "unique_id", compiled_id):
+            raise DbtProjectError(
+                f"binding the view ancestor {node.name!r}: {selector!r} compiled "
+                f"{compiled_id!r} instead — please report this.")
         sql = self._compiled[key][2]
         schema, database = getattr(node, "schema", None), getattr(node, "database", None)
         if schema:
@@ -711,8 +757,8 @@ class DbtProject:
         # p.sql() later the delta_scan view is back and reads are correct again. Warning about a
         # hazard that repairs itself before it can mislead would be a false statement in a message
         # whose whole job is to be trusted.
-        if self.last_compile is not None and self.last_compile.node_id:
-            self._bind_view_ancestors(self.last_compile.node_id)
+        if self.last_compile is not None and (self.last_compile.node_id or self.last_compile.parents):
+            self._bind_view_ancestors(self.last_compile.node_id, self.last_compile.parents)
         return self._cursor.sql(sql)
 
 

--- a/tests/adapter/test_dbt_debug_cursor.py
+++ b/tests/adapter/test_dbt_debug_cursor.py
@@ -176,6 +176,39 @@ def test_scratch_objects_are_still_allowed(creds):
     assert cur.sql("select b from v_scratch").fetchall() == [(2,)]
 
 
+FILE_WRITES = [
+    "copy (select 1 as x) to '{out}' (format parquet)",
+    "copy \"memory\".\"main\".\"events\" to '{out}'",
+    "export database '{out}'",
+]
+
+
+@pytest.mark.parametrize("stmt", FILE_WRITES)
+def test_file_exports_are_rejected_and_nothing_lands_on_disk(tmp_path, creds, stmt):
+    """COPY ... TO / EXPORT DATABASE classify as passthrough — native DuckDB, no delta_rs — but
+    they write files wherever this session's live store credentials reach, and no read-only
+    delta_scan view sits downstream to refuse them. Here the check IS the safety, so the file must
+    not exist afterwards."""
+    from dbt.adapters.duckrun.environment import DuckrunReadOnlyError
+
+    out = tmp_path / "leak.out"
+    env, cur = _fresh_debug_cursor(creds)
+    with pytest.raises(DuckrunReadOnlyError):
+        cur.sql(stmt.format(out=out.as_posix()))
+    assert not out.exists()
+
+
+def test_copy_from_into_scratch_is_still_allowed(tmp_path, creds):
+    """COPY <table> FROM loads a file INTO the catalog — scratch territory, the same contract as
+    CREATE TEMP TABLE. Only the writing direction (a top-level TO) is refused."""
+    src = tmp_path / "in.csv"
+    src.write_text("a\n1\n2\n", encoding="utf-8")
+    env, cur = _fresh_debug_cursor(creds)
+    cur.sql("create temp table loaded (a int)")
+    cur.sql(f"copy loaded from '{src.as_posix()}' (header)")
+    assert cur.sql("select count(*) from loaded").fetchall() == [(2,)]
+
+
 # ── 3. the run path is unchanged ───────────────────────────────────────────────────────────────
 
 def test_run_cursor_still_writes_through_delta_rs(project, creds):

--- a/tests/adapter/test_dbt_project_debug.py
+++ b/tests/adapter/test_dbt_project_debug.py
@@ -92,6 +92,26 @@ where id > (select max(id) from {{ this }})
 {% endif %}
 """
 
+# Main queries a SELECT-keyword hunt gets wrong: a parenthesized UNION has no top-level SELECT at
+# all (every SELECT sits inside parens), and DuckDB's FROM-first syntax puts its only top-level
+# SELECT in the MIDDLE of the main query. Both must list and slice — the splitter walks the WITH
+# list's structure, it does not hunt for a keyword.
+CTE_UNION = """{{ config(materialized='table') }}
+with base as (select id, name from {{ ref('stg_items') }})
+(select id, name from base where id = 1)
+union all
+(select id, name from base where id = 2)
+"""
+CTE_FROM_FIRST = """{{ config(materialized='table') }}
+with base as (select id, name, amount from {{ ref('stg_items') }})
+from base select id, upper(name) as shout
+"""
+# DuckDB resolves unquoted identifiers case-insensitively; cte() must match names the same way.
+CTE_MIXED_CASE = """{{ config(materialized='table') }}
+with MixedTotals as (select id, amount * 2 as total from {{ ref('stg_items') }})
+select * from MixedTotals
+"""
+
 # A macro that emits an entire CTE — name, body and its own comment.
 MACRO = """{% macro scaled_cte(name, src, factor) %}
 {{ name }} as (
@@ -144,6 +164,9 @@ def project(tmp_path):
     (proj / "models" / "v_chained.sql").write_text(VIEW_OVER_VIEW, encoding="utf-8")
     (proj / "models" / "uses_view.sql").write_text(USES_VIEW, encoding="utf-8")
     (proj / "models" / "macro_model.sql").write_text(MACRO_MODEL, encoding="utf-8")
+    (proj / "models" / "cte_union.sql").write_text(CTE_UNION, encoding="utf-8")
+    (proj / "models" / "cte_from_first.sql").write_text(CTE_FROM_FIRST, encoding="utf-8")
+    (proj / "models" / "cte_mixed_case.sql").write_text(CTE_MIXED_CASE, encoding="utf-8")
     (proj / "macros" / "helpers.sql").write_text(MACRO, encoding="utf-8")
     (proj / "models" / "schema.yml").write_text(SCHEMA_YML, encoding="utf-8")
     os.environ["DBG2_PATH"] = (tmp_path / "wh").as_posix()
@@ -725,3 +748,90 @@ def test_importing_duckrun_does_not_import_dbts_cli():
     """)
     out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
     assert "CLI:False" in out.stdout, out.stdout
+
+
+# ── sql() over view models, and CTE shapes a keyword hunt got wrong ────────────────────────────
+
+def test_sql_reads_a_view_model_on_a_cold_session(p):
+    """`sql()` compiles inline, and the inline node is out of the manifest before anything runs
+    (dbt removes it on success, _drop_inline_node on failure) — so view-ancestor binding must start
+    from the compile's recorded parents. Before the fix the walk found nothing to register and the
+    ref died in the lazy bind (a view model never wrote a Delta table for it to find): show() of
+    the same model worked, sql() over a ref to it did not."""
+    rows = p.sql("select id, boosted from {{ ref('v_boosted') }} order by id").fetchall()
+    assert [(r[0], float(r[1])) for r in rows] == [(1, 105.0), (2, 205.0)]
+    # Through the two-level view chain too: binding must recurse, not stop at the first parent.
+    rows = p.sql("select id, doubled from {{ ref('v_chained') }} order by id").fetchall()
+    assert [(r[0], float(r[1])) for r in rows] == [(1, 210.0), (2, 410.0)]
+
+
+def test_a_parenthesized_union_main_lists_and_slices(p):
+    """`(select …) union all (select …)` as the main query has NO top-level SELECT, so the old
+    keyword hunt declined and ctes() reported [] — a false "has no CTEs" for a model that plainly
+    has one. The structural walk hands over at the `(` instead."""
+    assert p.ctes("cte_union") == ["base"]
+    rows = p.cte("cte_union", "base").fetchall()
+    assert sorted(r[0] for r in rows) == [1, 2]
+
+
+def test_a_from_first_main_slices_clean(p):
+    """DuckDB's FROM-first syntax (`from base select …`) puts the model's only top-level SELECT in
+    the middle of the main query. Hunting for it swallowed `from base` into the last CTE's text and
+    the splice ran two body clauses — invalid SQL about a model that was fine."""
+    assert p.ctes("cte_from_first") == ["base"]
+    rows = p.cte("cte_from_first", "base").fetchall()
+    assert sorted(r[0] for r in rows) == [1, 2]
+    assert sorted(r[1] for r in p.show("cte_from_first").fetchall()) == ["A", "B"]
+
+
+def test_cte_names_match_case_insensitively(p):
+    """DuckDB resolves unquoted identifiers case-insensitively, so `cte(m, 'mixedtotals')` must
+    find the CTE spelled MixedTotals. A name that matches nothing still lists the real ones."""
+    rows = p.cte("cte_mixed_case", "mixedtotals").fetchall()
+    assert sorted((r[0], float(r[1])) for r in rows) == [(1, 21.0), (2, 41.0)]
+    with pytest.raises(DbtProjectError) as exc:
+        p.cte("cte_mixed_case", "no_such_step")
+    assert "MixedTotals" in str(exc.value)
+
+
+def test_show_survives_a_same_named_model_in_a_package(tmp_path):
+    """A view ancestor is compiled by its full fqn, never its bare name: `--select v_boosted`
+    matches EVERY node of that name, so one same-named model in an installed package aborted
+    show() of a model the caller DID name unambiguously — with advice to "narrow the selector",
+    about a selector they never wrote."""
+    proj = tmp_path / "proj"
+    (proj / "models").mkdir(parents=True)
+    (proj / "dbt_project.yml").write_text(
+        "name: dbg\nversion: '1.0'\nconfig-version: 2\nprofile: dbg\nmodel-paths: [models]\n",
+        encoding="utf-8")
+    (proj / "profiles.yml").write_text(
+        "dbg:\n  target: dev\n  outputs:\n    dev:\n"
+        f"      type: duckrun\n      root_path: \"{(tmp_path / 'wh').as_posix()}\"\n",
+        encoding="utf-8")
+    (proj / "models" / "stg_items.sql").write_text(STG, encoding="utf-8")
+    (proj / "models" / "v_boosted.sql").write_text(VIEW_MODEL, encoding="utf-8")
+    (proj / "models" / "uses_boosted.sql").write_text(
+        "{{ config(materialized='table') }}\nselect * from {{ ref('v_boosted') }}\n",
+        encoding="utf-8")
+    # The same model NAME in a local package, on its own schema so dbt itself has no name clash —
+    # only bare-name selection is ambiguous.
+    pkg = tmp_path / "pkg"
+    (pkg / "models").mkdir(parents=True)
+    (pkg / "dbt_project.yml").write_text(
+        "name: pkglib\nversion: '1.0'\nconfig-version: 2\nmodel-paths: [models]\n"
+        "models:\n  pkglib:\n    +schema: pkgspace\n", encoding="utf-8")
+    (pkg / "models" / "v_boosted.sql").write_text(
+        "{{ config(materialized='view') }}\nselect 1 as one\n", encoding="utf-8")
+    (proj / "packages.yml").write_text("packages:\n  - local: ../pkg\n", encoding="utf-8")
+
+    assert dbtRunner().invoke(
+        ["deps", "--project-dir", str(proj), "--profiles-dir", str(proj), "--quiet"]).success
+    assert dbtRunner().invoke(
+        ["run", "--project-dir", str(proj), "--profiles-dir", str(proj), "--quiet",
+         "--exclude", "pkglib.*"]).success
+    from dbt.adapters.duckdb.connections import DuckDBConnectionManager
+    DuckDBConnectionManager.close_all_connections()
+
+    p = duckrun.dbt_project(proj)
+    rows = p.show("uses_boosted").fetchall()
+    assert [(r[0], float(r[2])) for r in sorted(rows)] == [(1, 105.0), (2, 205.0)]

--- a/tests/adapter/test_review_fixes.py
+++ b/tests/adapter/test_review_fixes.py
@@ -6,7 +6,7 @@ Pure-Python unit tests for the small, self-contained fixes — the ones that don
 import duckdb
 import pytest
 
-from dbt.adapters.duckrun import delta_dml, engine, policy, secret, sqlscan
+from dbt.adapters.duckrun import delta_dml, engine, policy, remote, secret, sqlscan
 from dbt.adapters.duckrun.credentials import DuckrunCredentials
 from dbt.adapters.duckrun.delta_plugin import Plugin
 from duckrun.session import _is_multi_statement
@@ -542,3 +542,23 @@ def test_geometry_config_validation():
             gc({"max_row_group_size": bad})
         with pytest.raises(ValueError):
             gc({"target_file_size_mb": bad})
+
+
+# ------------------------------------------------------- glob discovery fails loud
+
+def test_glob_listing_missing_dir_is_empty_not_error(tmp_path):
+    """The benign case stays benign: DuckDB's glob yields zero rows for a path that does not exist
+    (a schema dir before the first write), no exception — so discovery sees an empty schema."""
+    con = duckdb.connect()
+    assert remote.list_delta_tables_via_glob(con, (tmp_path / "nope").as_posix(), "dbo") == []
+
+
+def test_glob_listing_store_error_raises(tmp_path):
+    """A store we genuinely cannot see must abort discovery, not read as an empty schema: an empty
+    listing makes every table vanish from the relation cache, flips is_incremental() off, and the
+    next run full-refreshes over the table — the same silent clobber the OneLake lister fails loud
+    on. az:// with no secret is the cheapest real store failure (and if the azure extension itself
+    cannot load, that raises too — equally a listing failure, never [])."""
+    con = duckdb.connect()
+    with pytest.raises(duckdb.Error):
+        remote.list_delta_tables_via_glob(con, "az://no-secret-container/x", "dbo")

--- a/tests/dbt_unit_tests/project/models/marts/alias_precedence_layout.sql
+++ b/tests/dbt_unit_tests/project/models/marts/alias_precedence_layout.sql
@@ -1,0 +1,9 @@
+-- Upstream (dbt-duckdb 1.11) alias precedence: the canonical partitioned_by wins over a legacy
+-- partition_by unless it is none or '' — and an EMPTY column list is a hard compiler error, never
+-- a silent fall-through to the legacy key or a silently unpartitioned table. The vars let the
+-- mirror test drive each case, including the expected failures, without a project of its own.
+{{ config(materialized='table',
+          partitioned_by=var('alias_partitioned_by', none),
+          partition_by=var('alias_partition_by', none)) }}
+
+select * from (values (1, 'a'), (2, 'b'), (3, 'a')) as t(id, bucket)

--- a/tests/dbt_unit_tests/test_dbt_unit_tests.py
+++ b/tests/dbt_unit_tests/test_dbt_unit_tests.py
@@ -146,6 +146,24 @@ def test_canonical_spellings_sorted_by_partitioned_by(tmp_path):
         assert keys == sorted(keys), f"partition {bucket} not physically sorted: {keys}"
 
 
+def test_alias_precedence_matches_upstream(tmp_path):
+    """dbt-duckdb 1.11's precedence, exactly: when both spellings are set the canonical
+    partitioned_by wins, and a canonical EMPTY list is upstream's compiler error ("must contain at
+    least one column") — never a silent fall-through to the legacy key (which would partition a
+    model whose config explicitly said not to) and never a silently unpartitioned table."""
+    from deltalake import DeltaTable
+
+    wh = _wh(tmp_path)
+    assert _dbt(wh, "run", "--select", "alias_precedence_layout", "--vars",
+                "{alias_partitioned_by: ['bucket'], alias_partition_by: ['id']}").success
+    dt = DeltaTable(f"{wh}/{SCHEMA}/alias_precedence_layout")
+    assert dt.metadata().partition_columns == ["bucket"], dt.metadata().partition_columns
+
+    res = _dbt(wh, "run", "--select", "alias_precedence_layout", "--vars",
+               "{alias_partitioned_by: [], alias_partition_by: ['id']}")
+    assert not res.success, "partitioned_by: [] must be an error, not a fall-through"
+
+
 def test_geometry_configs_reach_the_writer(tmp_path):
     """max_row_group_size / target_file_size_mb must survive the materialization macro's config
     hand-off. This is the hop that broke in 0.4.43: _delta_core.sql's delta_config carried sort_by


### PR DESCRIPTION
## What

Six confirmed bugs from a correctness review of everything added since v0.4.45 (the #29 debug-API series, the 1.11.0 compat resync, discovery). Every one was reproduced before it was fixed, and each fix's repro became its test.

### Debug session (#29 follow-ups)
1. **`p.sql()` over a `ref()` to a view model died on a cold session** (`CatalogException`). The inline node is out of the manifest before anything runs — dbt removes it on success, `_drop_inline_node` on failure — so view-ancestor binding, which starts from the node id, silently registered nothing and the ref fell into the lazy bind, which only knows Delta tables. `show()` of the same model worked, making it read as a user error. The compile now records the inline node's direct parents and binding walks from them.
2. **A same-named model in an installed package aborted `show()` of an unambiguous model** — view ancestors were compiled by bare name, and `--select v_boosted` matches every node of that name. The error even advised narrowing a selector the caller never wrote. Ancestors now compile by full dotted fqn with the returned node id checked.
3. **CTE slicing hunted for a top-level `SELECT`**, so a parenthesized-UNION main (`(select …) union all (select …)`) reported a false *"has no CTEs"*, and a FROM-first main (`from base select …`) got spliced into invalid SQL (the last CTE swallowed `from base`). The splitter now walks the WITH list's structure and hands over wherever the main query starts. Unsliceable WITH lists say so honestly, and `cte()` matches names case-insensitively, as DuckDB itself resolves identifiers.
4. **The read-only debug cursor now refuses `COPY … TO` / `EXPORT DATABASE`.** They classify as passthrough (native DuckDB, no delta_rs route) but write files wherever the session's live store credentials reach — including the lakehouse — and no read-only view sits downstream to refuse them. `COPY <table> FROM …` into scratch still works. Docs updated.

### Discovery
5. **Glob discovery (local/az/s3/gs) converted real store errors into an empty schema.** DuckDB's `glob` already yields zero rows, no error, for a missing schema dir — so the blanket `except → []` only ever masked genuine failures (missing secret, transport error, absent bucket). An empty listing empties dbt's relation cache, flips `is_incremental()` off, and the next run full-refreshes over the table — the exact clobber OneLake discovery (fe9cc85) fails loud on. Glob stores now share that contract.

### 1.11.0 compat
6. **`partitioned_by`/`sorted_by` precedence now matches dbt-duckdb 1.11 verbatim.** The truthiness `or` let a canonical empty list (`partitioned_by: []`, an explicit "no partitioning") silently fall through to a legacy `partition_by` — the model got partitioned against its own config. Upstream keeps the canonical value unless it is none/`''` and rejects an empty column list ("must contain at least one column"); `_delta_core.sql` and `seed.sql` now do both.

## Verified
- Each bug reproduced on a tiny local project before the fix, green after; probes for the splitter run the full shape grid (paren-union, FROM-first, column lists, quoted names with commas, comments, literals).
- New coverage folded into the existing files: `test_dbt_project_debug.py` (+5), `test_dbt_debug_cursor.py` (+4 incl. nothing-lands-on-disk), `test_review_fixes.py` (+2 glob), `test_dbt_unit_tests.py` (+1 alias precedence, var-driven model).
- Locally: 18 new/neighboring tests green; full `test_review_fixes.py` green. cores (3.11+3.12) is the real gate.

Found alongside (report-only, no code change here): the branch probe was cleared of the suspected transitive-ephemeral corruption (verified clean both orders), and `delta_column_stats`' column-mapping key resolution verified correct against the vendored fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)