### PR TITLE
release: 0.4.48

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "duckrun"
-version = "0.4.47"
+version = "0.4.48"
 description = "A dbt adapter that runs SQL in DuckDB and materializes to Delta Lake (delta_rs)."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Patch release carrying #35 — the debug-session correctness sweep (sql() view refs, fqn ancestor compile, structural CTE split, file-export guard on the read-only cursor), fail-loud glob discovery, and dbt-duckdb 1.11 alias precedence.

Version bump only; tagging v0.4.48 on the merge commit triggers publish (cores + local-stress gates, then PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)