### PR TITLE
release: 0.4.49

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "duckrun"
-version = "0.4.48"
+version = "0.4.49"
 description = "A dbt adapter that runs SQL in DuckDB and materializes to Delta Lake (delta_rs)."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump for the 0.4.49 release. Ships #38 — measure tail slots in the auto sort-key model (model v3).

Tag `v0.4.49` goes on this PR's squash-merge commit once CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)