### PR TITLE
release: 0.4.50

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "duckrun"
-version = "0.4.49"
+version = "0.4.50"
 description = "A dbt adapter that runs SQL in DuckDB and materializes to Delta Lake (delta_rs)."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Patch release carrying the #42 fix (PR #43): naive TIMESTAMP columns land as UTC-adjusted Delta `timestamp` by default instead of `timestamp_ntz`, which Fabric's SQL analytics endpoint silently omits. Escape hatch: `timestamp_ntz: true` / `DUCKRUN_TIMESTAMP_NTZ=1`; existing NTZ tables keep working (skip + warning) until a `--full-refresh` retypes them. Also fixes bare `CREATE TABLE (… TIMESTAMPTZ)` in non-UTC sessions.

Version bump only — tag `v0.4.50` goes on the squash-merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)