### PR TITLE
feat: ship materialized='external'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **`materialized='external'`** — the last materialization dbt-duckdb had and duckrun didn't. A
+  model can now be exported as a plain parquet/csv/json file (DuckDB `COPY … TO`) and is surfaced as
+  a view over that file, for hand-off to tools that don't read Delta. It is dbt-duckdb's macro
+  shipped under duckrun's adapter name — same configs (`location`, `format`, `options`,
+  `*_read_options`, `plugin`/`glue_register`), same defaults (`<external_root>/<identifier>.<format>`),
+  same output — because dbt resolves a materialization by exact adapter name and dbt-duckdb's
+  `adapter="duckdb"` one was simply unreachable from `type: duckrun`. External and Delta models
+  `ref()` each other freely within a run; as upstream, a run that reads an external model *without*
+  rebuilding it needs `on-run-start: "{{ register_upstream_external_models() }}"`, since duckrun's
+  disk discovery only rediscovers Delta tables.
+
 ### Changed
 - **Naive `TIMESTAMP` columns are written UTC-adjusted by default — Delta `timestamp`, not
   `timestamp_ntz`** (#42). Fabric's SQL analytics endpoint does not support `timestamp_ntz` and

--- a/dbt/include/duckrun/macros/materializations/external.sql
+++ b/dbt/include/duckrun/macros/materializations/external.sql
@@ -1,0 +1,224 @@
+{#
+  `external` materialization — write the model to a real parquet/csv/json FILE and surface it as
+  a view over that file. Unlike every other duckrun materialization, nothing here touches Delta:
+  DuckDB's own `COPY ... TO` writes the bytes.
+
+  This is dbt-duckdb's macro, near-verbatim. dbt resolves a materialization by exact adapter name
+  with only a `default` fallback (unlike `adapter.dispatch`, which walks duckrun -> duckdb ->
+  default because the plugin declares dependencies=['duckdb']), so dbt-duckdb's
+  `{% materialization external, adapter="duckdb" %}` is unreachable from `type: duckrun` and an
+  external model errored. Copying it under adapter='duckrun' is the whole fix — every helper it
+  calls (external_location, render_write_options, write_to_file, store_relation, create_table_as)
+  and every adapter method (external_root, external_write_options, external_read_location) is
+  already dbt-duckdb's, inherited.
+
+  Keep this a copy: divergence from upstream is a compatibility bug, not an improvement. The one
+  intentional difference is that upstream's stray `)` after the `location` line (which renders a
+  literal `)` into the output) is not reproduced.
+
+  Note `location` means something different here than in the Delta materializations: for
+  table/incremental it is the Delta table path (duckrun__delta_location); here it is the output
+  FILE path, defaulting to `{{ external_root }}/{{ identifier }}.{{ format }}`.
+
+  The model relation is a DuckDB view over the file, and disk discovery only rebuilds Delta
+  tables — so, exactly as upstream, a run that doesn't rebuild an external model needs
+  `on-run-start: "{{ register_upstream_external_models() }}"` to resolve it.
+#}
+{% materialization external, adapter='duckrun', supported_languages=['sql', 'python'] %}
+
+  {%- set location = render(config.get('location', default=external_location(this, config))) -%}
+  {%- set rendered_options = render_write_options(config) -%}
+
+  {%- set format = config.get('format') -%}
+  {%- set allowed_formats = ['csv', 'parquet', 'json'] -%}
+  {%- if format -%}
+      {%- if format not in allowed_formats -%}
+          {{ exceptions.raise_compiler_error("Invalid format: " ~ format ~ ". Allowed formats are: " ~ allowed_formats | join(', ')) }}
+      {%- endif -%}
+  {%- else -%}
+    {%- set format = location.split('.')[-1].lower() if '.' in location else 'parquet' -%}
+    {%- set format = format if format in allowed_formats else 'parquet' -%}
+  {%- endif -%}
+
+  {%- set write_options = adapter.external_write_options(location, rendered_options) -%}
+  {%- set read_location = adapter.external_read_location(location, rendered_options) -%}
+  {%- set parquet_read_options = config.get('parquet_read_options', {'union_by_name': False}) -%}
+  {%- set json_read_options = config.get('json_read_options', {'auto_detect': True}) -%}
+  {%- set csv_read_options = config.get('csv_read_options', {'auto_detect': True}) -%}
+
+  -- set language - python or sql
+  {%- set language = model['language'] -%}
+
+  {%- set target_relation = this.incorporate(type='view') %}
+
+  -- Continue as normal materialization
+  {%- set existing_relation = load_cached_relation(this) -%}
+  {%- set temp_relation =  make_intermediate_relation(this.incorporate(type='table'), suffix='__dbt_tmp') -%}
+  {%- set intermediate_relation =  make_intermediate_relation(target_relation, suffix='__dbt_int') -%}
+  -- the intermediate_relation should not already exist in the database; get_relation
+  -- will return None in that case. Otherwise, we get a relation that we can drop
+  -- later, before we try to use this name for the current operation
+  {%- set preexisting_temp_relation = load_cached_relation(temp_relation) -%}
+  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
+  /*
+      See ../view/view.sql for more information about this relation.
+  */
+  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}
+  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
+  -- as above, the backup_relation should not already exist
+  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
+  -- grab current tables grants config for comparision later on
+  {% set grant_config = config.get('grants') %}
+
+  -- drop the temp relations if they exist already in the database
+  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
+  {{ drop_relation_if_exists(preexisting_temp_relation) }}
+  {{ drop_relation_if_exists(preexisting_backup_relation) }}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  -- build model
+  {#-- A NATIVE DuckDB table, not a Delta one: duckrun's cursor only rewrites `create table ... as
+       <select>` into a Delta write when the body is an unqualified select, and create_table_as
+       always wraps it as `as ( ... )`. See delta_dml._create_as. --#}
+  {% call statement('create_table', language=language) -%}
+    {{- create_table_as(False, temp_relation, compiled_code, language) }}
+  {%- endcall %}
+
+  -- check if relation is empty
+  {%- set count_query -%}
+    select count(*) as row_count from {{ temp_relation }}
+  {%- endset -%}
+  {%- set row_count = run_query(count_query) -%}
+
+  -- if relation is empty, write a non-empty table with column names and null values
+  {% call statement('main', language='sql') -%}
+    {% if row_count[0][0] == 0 %}
+    insert into {{ temp_relation }} values (
+      {%- for col in get_columns_in_relation(temp_relation) -%}
+      NULL,
+      {%- endfor -%}
+    )
+    {% endif %}
+  {%- endcall %}
+
+  -- write a temp relation into file
+  {{ write_to_file(temp_relation, location, write_options) }}
+
+-- create a view on top of the location
+  {% call statement('main', language='sql') -%}
+    {% if format == 'json' %}
+      create or replace view {{ intermediate_relation }} as (
+        select * from read_json('{{ read_location }}'
+        {%- for key, value in json_read_options.items() -%}
+          , {{ key }}=
+          {%- if value is string -%}
+            '{{ value }}'
+          {%- else -%}
+            {{ value }}
+          {%- endif -%}
+        {%- endfor -%}
+        )
+        -- if relation is empty, filter by all columns having null values
+        {% if row_count[0][0] == 0 %}
+          where 1
+          {%- for col in get_columns_in_relation(temp_relation) -%}
+            {{ '' }} AND "{{ col.column }}" is not NULL
+          {%- endfor -%}
+        {% endif %}
+      );
+    {% elif format == 'parquet' %}
+      create or replace view {{ intermediate_relation }} as (
+        select * from read_parquet('{{ read_location }}'
+        {%- for key, value in parquet_read_options.items() -%}
+          , {{ key }}=
+          {%- if value is string -%}
+            '{{ value }}'
+          {%- else -%}
+            {{ value }}
+          {%- endif -%}
+        {%- endfor -%}
+        )
+        -- if relation is empty, filter by all columns having null values
+        {% if row_count[0][0] == 0 %}
+          where 1
+          {%- for col in get_columns_in_relation(temp_relation) -%}
+            {{ '' }} AND "{{ col.column }}" is not NULL
+          {%- endfor -%}
+        {% endif %}
+      );
+    {% elif format == 'csv' %}
+    create or replace view {{ intermediate_relation }} as (
+      select * from read_csv('{{ read_location }}'
+      {%- for key, value in csv_read_options.items() -%}
+        , {{ key }}=
+        {%- if value is string -%}
+          '{{ value }}'
+        {%- else -%}
+          {{ value }}
+        {%- endif -%}
+      {%- endfor -%}
+      )
+      -- if relation is empty, filter by all columns having null values
+      {% if row_count[0][0] == 0 %}
+        where 1
+        {%- for col in get_columns_in_relation(temp_relation) -%}
+          {{ '' }} AND "{{ col.column }}" is not NULL
+        {%- endfor -%}
+      {% endif %}
+    );
+    {% endif %}
+  {%- endcall %}
+
+  -- cleanup
+  {% if existing_relation is not none %}
+      {{ adapter.rename_relation(existing_relation, backup_relation) }}
+  {% endif %}
+
+  {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  -- `COMMIT` happens here
+  {{ adapter.commit() }}
+
+  -- finally, drop the existing/backup relation after the commit
+  {{ drop_relation_if_exists(backup_relation) }}
+  {#-- The one deviation from upstream: drop the staging relation with a bare `drop table if
+       exists` instead of drop_relation, which appends CASCADE. A python model is staged by
+       py_write_table as `create table … as select …` — the one form duckrun's cursor rewrites into
+       a delta_rs write (delta_dml._create_as) — so by now the relation is a delta_scan VIEW, and
+       the CASCADE form matches neither the router's `drop table` pattern (which would tombstone it)
+       nor a DuckDB view ("Existing object is of type View, trying to drop type Table"). Without
+       CASCADE both cases work: a SQL model's native staging table is dropped by DuckDB, a python
+       model's Delta staging table is tombstoned. duckrun's own materializations drop the same way
+       (_delta_core.sql). --#}
+  {% call statement('drop_stage') -%}
+    drop table if exists {{ temp_relation }}
+  {%- endcall %}
+
+  -- register table into glue
+  {%- set plugin_name = config.get('plugin') -%}
+  {%- set glue_register = config.get('glue_register', default=false) -%}
+  {%- set partition_columns = config.get('partition_columns', []) -%}
+  {% if plugin_name is not none or glue_register is true %}
+    {% if glue_register %}
+      {# legacy hack to set the glue database name, deprecate this #}
+      {%- set plugin_name = 'glue|' ~ config.get('glue_database', 'default') -%}
+    {% endif %}
+    {% do store_relation(plugin_name, target_relation, location, format, config) %}
+  {% endif %}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{% endmaterialization %}

--- a/docs/dbt-adapter.md
+++ b/docs/dbt-adapter.md
@@ -226,6 +226,7 @@ on-run-start:
 | `view`            | in-memory DuckDB         | Ephemeral staging within a run (inherited from dbt-duckdb).            |
 | `seed`            | Delta (overwrite)        | CSV loaded via DuckDB, then persisted as a Delta table — survives across processes like a model. |
 | `delta`           | Delta                    | Alias for `table`; honors `incremental=true`. Kept for convenience.   |
+| `external`        | a parquet / csv / json **file** | Not Delta: DuckDB `COPY … TO` writes the file, and the model is a view over it ([below](#external)). |
 
 The persisted materializations (`table`, `incremental`, `delta`, `seed`) register a `delta_scan` view
 over the new Delta table, so downstream `ref()` works — and because a seed is now a real Delta table,
@@ -372,6 +373,45 @@ whatever the previous attempt already loaded.
 > Earlier versions exposed this as a separate `append_if_unchanged` strategy. That's gone — the
 > behavior is now automatic on `append` whenever the model reads `{{ this }}`, so there's no strategy
 > to pick. First run (or `--full-refresh`, or a missing table) overwrites to create the table.
+
+### `external`
+
+The one materialization that doesn't write Delta. It is dbt-duckdb's, shipped verbatim under
+duckrun's adapter name, for exporting a model as a plain file — a hand-off to a tool that reads
+parquet/CSV/JSON but not Delta.
+
+```sql
+{{ config(materialized='external', location='exports/orders.parquet') }}
+
+select * from {{ ref('mart_orders') }}
+```
+
+DuckDB runs the SQL, `COPY … TO` writes the file, and the model relation becomes a view over that
+file — so downstream `ref()` works within the run, and a Delta `table` model can read an external one
+(and vice versa). Everything is upstream's: same config spelling, same defaults, same output.
+
+| option | description |
+|---|---|
+| `location` | output **file** path. Defaults to `<external_root>/<identifier>.<format>` (`external_root` is a profile key, `.` if unset). Note this is a *file*, unlike the `location` of a Delta materialization. |
+| `format` | `parquet` (default) \| `csv` \| `json`. Inferred from `location`'s extension when omitted. |
+| `options` | dict spliced into `COPY … TO (…)` — e.g. `{'partition_by': 'year,month'}`, `{'per_thread_output': true}`, `{'compression': 'zstd'}`. |
+| `delimiter` | legacy top-level alias, folded into `options`. |
+| `parquet_read_options` / `csv_read_options` / `json_read_options` | args for the `read_*` call the view is built from. |
+| `plugin`, `glue_register`, `glue_database`, `partition_columns` | register the written file with a dbt-duckdb plugin (e.g. the AWS Glue catalog) after the write. |
+
+Two things to know, both inherited from how duckrun stores state:
+
+- **The view doesn't survive the process.** duckrun's DuckDB is in-memory and its disk discovery
+  rebuilds Delta tables only, so a later run that reads an external model *without* rebuilding it
+  (`dbt run --select some_downstream`) needs upstream's hook — exactly as on dbt-duckdb:
+
+  ```yaml
+  # dbt_project.yml
+  on-run-start: "{{ register_upstream_external_models() }}"
+  ```
+
+- **`--full-refresh` means nothing here** — every run rewrites the file wholesale. There is no
+  incremental external model, upstream or here.
 
 ### Config options (`table` / `incremental` / `delta`)
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -13,7 +13,6 @@ on duckrun, their own tests included. These are the places where it is *not* the
 |---|---|---|
 | `type: duckrun` is its own adapter type | an existing project's **profile** must say `type: duckrun`; a `type: duckdb` profile cannot be rerouted | dbt selects the adapter from `type`. The project itself needs no edit — in dbt the profile lives outside it (that's how the parity runs work, via `--profiles-dir`) |
 | `materialized='view'` | runs, but is a connection-scoped DuckDB view — nothing on storage, gone next session; swapping a model `table` ⇄ `view` isn't supported | Delta defines no view ([below](#materializations)) |
-| `materialized='external'` | **errors** — duckrun doesn't ship it | materializations dispatch by adapter name, so there's no fallback to dbt-duckdb's. Every duckrun model is already an external table, just in Delta |
 | `materialized='table_function'` | **errors** — duckrun doesn't ship it | a DuckDB table macro is catalog-only state, and duckrun's DuckDB is in-memory, so it could only ever live for the length of one run |
 | `threads` | honored, but concurrent writers share one memory budget; a microbatch model's batches still run in order | DuckDB's `memory_limit` is per database, not per model, and a microbatch model's batches all write the same table ([below](#dbt-incremental)) |
 | `on_schema_change='sync_all_columns'` | only *adds* columns | delta-rs can't drop columns ([below](#schema-constraints)) |
@@ -25,7 +24,8 @@ Everything else carries over: `DuckrunCredentials` subclasses dbt-duckdb's, so t
 surface (`attach`, `secrets`, `settings`, `extensions`, `plugins`, `filesystems`, `remote`, `retries`,
 `external_root`, `module_paths`, `disable_transactions`, …) is the same object, not a reimplementation.
 Seeds, snapshots, native `unit_tests:`, data tests, exposures, python models, `external_location`
-sources, and the full merge-config surface (`merge_clauses` — including `do_nothing`, the implicit
+sources, `materialized='external'` (dbt-duckdb's macro, shipped under duckrun's adapter name — see
+[below](#materializations)), and the full merge-config surface (`merge_clauses` — including `do_nothing`, the implicit
 clause defaults, `mode`, `by: source`, `insert: {columns, values}` — and
 `merge_update_set_expressions`) all behave as they do upstream. duckrun's own additions
 (`incremental_strategy='insert'`, `partition_by`, `sort_by`, `location`, `catalogs`) are a superset:
@@ -133,6 +133,14 @@ The full accepted/rejected matrix is in the [Connection API](connection-api.md#r
   rest of the session — but it lives only in that connection and vanishes when it closes; nothing is
   saved to storage, so the next session won't see it. (And swapping a model between `table` and
   `view` isn't supported.)
+- **`materialized='external'` needs an on-run-start hook to be visible to a later run.** External
+  models work as they do upstream — the model is written as a real parquet/csv/json file by DuckDB's
+  `COPY … TO` and surfaced as a view over that file — but duckrun's disk discovery only rebuilds
+  **Delta** tables, so the view is gone once the process ends. As on dbt-duckdb, a run that reads an
+  external model without rebuilding it (`dbt run --select some_downstream_model`) needs
+  `on-run-start: "{{ register_upstream_external_models() }}"` in `dbt_project.yml`. Note also that
+  `location` means the output **file** for an external model, and the **Delta table path** for
+  `table`/`incremental`.
 - **`DROP TABLE` is a soft tombstone, not a physical delete.** `conn.sql("drop table x")` unregisters
   the table and writes a tombstone marker but **does not reclaim the data files** (a deliberate
   precaution — you purge them when you're sure). Address dropped tables by name, not by path.

--- a/plugins/duckrun-projects/skills/duckrun-projects/SKILL.md
+++ b/plugins/duckrun-projects/skills/duckrun-projects/SKILL.md
@@ -219,9 +219,16 @@ Patterns worth reusing from this:
 | `incremental` | Delta merge / append | Grow or upsert; strategy below |
 | `view` | in-memory DuckDB | Ephemeral staging within a run |
 | `seed` | in-memory DuckDB | CSV fixtures |
+| `external` | a parquet/csv/json **file** | Exporting to a tool that can't read Delta |
 
 `table`, `incremental` (and the `delta` alias) register a `delta_scan` view after
 writing, so downstream `ref()` sees fresh data immediately.
+
+`external` is dbt-duckdb's materialization, unchanged: `COPY … TO` writes the file at
+`location` (default `<external_root>/<identifier>.<format>`) and the model becomes a view
+over it. Because duckrun only rediscovers *Delta* tables in a fresh process, a run that
+reads an external model without rebuilding it needs
+`on-run-start: "{{ register_upstream_external_models() }}"`, same as upstream.
 
 ## Choosing an incremental strategy — the decision that matters most
 

--- a/tests/adapter/test_external.py
+++ b/tests/adapter/test_external.py
@@ -1,0 +1,206 @@
+"""`materialized='external'` through a REAL `dbt run`.
+
+duckrun ships dbt-duckdb's external materialization (macros/materializations/external.sql) so a
+project can export a model as a plain parquet/csv/json file instead of a Delta table. Nothing about
+that path is duckrun's own code — it is upstream's macro plus upstream's adapter helpers — so what
+needs pinning is the *interaction* with duckrun:
+
+  * the statements it emits (`create table … as (select …)`, `insert … values`, `copy … to`,
+    `create view`, `drop table`) must all stay NATIVE DuckDB. duckrun rewrites raw DML into
+    delta_rs calls at the cursor (delta_dml.py); if any of these were intercepted, an external
+    model would quietly write Delta instead of the file it promised.
+  * the model relation is a view over the file, and duckrun's disk discovery only rebuilds Delta
+    tables — so a *later* run that doesn't rebuild the external model needs upstream's
+    `register_upstream_external_models()` on-run-start hook to see it.
+  * external and Delta models have to coexist in one run and `ref()` each other.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import duckdb
+import duckrun
+import pytest
+
+from dbt.cli.main import dbtRunner
+
+
+def _project(tmp_path, models, on_run_start=None):
+    """Write a dbt project whose models are `{name: sql}`, on a fresh local lakehouse root.
+
+    Returns (project_dir, root_path, external_root). `root_path` is where Delta tables land,
+    `external_root` where external models write their files — kept apart so a stray Delta write
+    under an external-only project is obvious.
+    """
+    proj = tmp_path / "proj"
+    (proj / "models").mkdir(parents=True)
+    (proj / "dbt_project.yml").write_text(
+        "name: ext\nversion: '1.0'\nconfig-version: 2\nprofile: ext\n"
+        "model-paths: [models]\n"
+        + (f'on-run-start: "{on_run_start}"\n' if on_run_start else ""),
+        encoding="utf-8")
+    (proj / "profiles.yml").write_text(
+        "ext:\n  target: dev\n  outputs:\n    dev:\n"
+        "      type: duckrun\n"
+        "      root_path: \"{{ env_var('EXT_ROOT_PATH') }}\"\n"
+        "      external_root: \"{{ env_var('EXT_EXTERNAL_ROOT') }}\"\n",
+        encoding="utf-8")
+    for name, sql in models.items():
+        suffix = ".py" if name.endswith("_py") else ".sql"
+        (proj / "models" / f"{name}{suffix}").write_text(sql, encoding="utf-8")
+
+    root = (tmp_path / "wh").as_posix()
+    exports = (tmp_path / "exports").as_posix()
+    Path(exports).mkdir()
+    os.environ["EXT_ROOT_PATH"] = root
+    os.environ["EXT_EXTERNAL_ROOT"] = exports
+    return proj, root, exports
+
+
+def _dbt(proj: Path, *args: str):
+    return dbtRunner().invoke([*args, "--project-dir", str(proj), "--profiles-dir", str(proj)])
+
+
+def _delta_logs(root):
+    """Every Delta table under the lakehouse root — a table exists iff it has a _delta_log."""
+    return sorted(p.parent.name for p in Path(root).rglob("_delta_log"))
+
+
+def test_parquet_default_location_and_delta_downstream(tmp_path):
+    """The headline path: an external model writes `<external_root>/<identifier>.parquet`, and a
+    Delta `table` model in the SAME run reads it through ref() — the two materializations coexist
+    and the export is a real parquet file, not a Delta table."""
+    proj, root, exports = _project(tmp_path, {
+        "ext_orders": "{{ config(materialized='external') }}\n"
+                      "select 1 as id, 'a' as name union all select 2, 'b'",
+        "mart_orders": "{{ config(materialized='table') }}\n"
+                       "select id, upper(name) as name from {{ ref('ext_orders') }}",
+    })
+    assert _dbt(proj, "run").success
+
+    export = Path(exports) / "ext_orders.parquet"
+    assert export.is_file()
+    assert duckdb.sql(f"select id, name from read_parquet('{export.as_posix()}') order by id"
+                      ).fetchall() == [(1, "a"), (2, "b")]
+
+    # ref() resolved through the view over the file, and only the Delta model wrote Delta.
+    con = duckrun.connect(root, schema="main", read_only=True)
+    assert con.sql("select id, name from mart_orders order by id").fetchall() == [(1, "A"), (2, "B")]
+    assert _delta_logs(root) == ["mart_orders"]
+
+    # Run 2 goes down the other branch — the existing relation is renamed to a backup and dropped
+    # after the swap — and must land in the same place with the same contents.
+    assert _dbt(proj, "run").success
+    assert duckdb.sql(f"select id, name from read_parquet('{export.as_posix()}') order by id"
+                      ).fetchall() == [(1, "a"), (2, "b")]
+    assert _delta_logs(root) == ["mart_orders"]
+
+
+def test_external_only_project_writes_no_delta(tmp_path):
+    """The regression guard for duckrun's DML interception. `create table … as (select …)`,
+    `insert … values`, `copy … to` and `drop table` all have to pass through to DuckDB: if the
+    staging CTAS were rewritten into a delta_rs write (delta_dml._create_as), the temp relation
+    would become a Delta table under root_path and the file would be written from a delta_scan."""
+    proj, root, exports = _project(tmp_path, {
+        "ext_only": "{{ config(materialized='external') }}\nselect 1 as id",
+    })
+    assert _dbt(proj, "run").success
+
+    assert (Path(exports) / "ext_only.parquet").is_file()
+    assert _delta_logs(root) == []                       # nothing Delta was written at all
+    assert not list(Path(root).rglob("*__dbt_tmp"))      # and no staging leftovers
+
+
+@pytest.mark.parametrize("name, config, filename", [
+    ("ext_csv", "materialized='external', format='csv'", "ext_csv.csv"),
+    ("ext_json", "materialized='external', location=\"{{ env_var('EXT_EXTERNAL_ROOT') }}/o.json\"",
+     "o.json"),
+])
+def test_format_explicit_and_inferred_from_extension(tmp_path, name, config, filename):
+    """`format:` picks the writer; with no `format:` it is inferred from the location's extension
+    (upstream's rule), and the default location carries the format as its extension."""
+    proj, root, exports = _project(tmp_path, {
+        name: "{{ config(" + config + ") }}\nselect 1 as id, 'a' as name",
+    })
+    assert _dbt(proj, "run").success
+
+    export = Path(exports) / filename
+    assert export.is_file()
+    reader = "read_csv" if export.suffix == ".csv" else "read_json"
+    assert duckdb.sql(f"select id, name from {reader}('{export.as_posix()}')"
+                      ).fetchall() == [(1, "a")]
+
+
+def test_partitioned_export_globs_back_through_ref(tmp_path):
+    """`options: {partition_by: …}` makes the location a hive directory, so the read view has to
+    glob it back (adapter.external_read_location) for ref() to see every partition."""
+    proj, root, exports = _project(tmp_path, {
+        "ext_parts": "{{ config(materialized='external', options={'partition_by': 'g'}) }}\n"
+                     "select 1 as id, 'x' as g union all select 2, 'y'",
+        "mart_parts": "{{ config(materialized='table') }}\n"
+                      "select count(*) as n from {{ ref('ext_parts') }}",
+    })
+    assert _dbt(proj, "run").success
+
+    assert (Path(exports) / "ext_parts" / "g=x").is_dir()
+    assert (Path(exports) / "ext_parts" / "g=y").is_dir()
+    con = duckrun.connect(root, schema="main", read_only=True)
+    assert con.sql("select n from mart_parts").fetchall() == [(2,)]
+
+
+def test_empty_model_reads_back_empty(tmp_path):
+    """An empty result can't be written as a schema-less file, so upstream writes one all-NULL
+    sentinel row and filters it out in the read view. Downstream must see zero rows."""
+    proj, root, exports = _project(tmp_path, {
+        "ext_empty": "{{ config(materialized='external') }}\n"
+                     "select 1 as id, 'a' as name where false",
+        "mart_empty": "{{ config(materialized='table') }}\n"
+                      "select count(*) as n from {{ ref('ext_empty') }}",
+    })
+    assert _dbt(proj, "run").success
+
+    assert (Path(exports) / "ext_empty.parquet").is_file()
+    con = duckrun.connect(root, schema="main", read_only=True)
+    assert con.sql("select n from mart_empty").fetchall() == [(0,)]
+
+
+def test_python_external_model(tmp_path):
+    """External supports python models too (`supported_languages=['sql', 'python']`)."""
+    proj, root, exports = _project(tmp_path, {
+        "ext_py": 'def model(dbt, session):\n'
+                  '    dbt.config(materialized="external")\n'
+                  '    return session.sql("select 7 as id")\n',
+    })
+    assert _dbt(proj, "run").success
+
+    export = Path(exports) / "ext_py.parquet"
+    assert export.is_file()
+    assert duckdb.sql(f"select id from read_parquet('{export.as_posix()}')").fetchall() == [(7,)]
+
+
+def test_upstream_external_model_resolves_in_a_fresh_process(tmp_path):
+    """duckrun's DuckDB is in-memory and its disk discovery only rebuilds DELTA tables, so an
+    external model's view does not survive the process that built it. Upstream's answer is the
+    `register_upstream_external_models()` on-run-start hook, which duckrun inherits verbatim
+    (it is a plain macro, so no adapter dispatch is involved). Pin it in a genuinely separate
+    process — in-process the DuckDB environment is a singleton and the view would still be there.
+    """
+    proj, root, exports = _project(tmp_path, {
+        "ext_src": "{{ config(materialized='external') }}\nselect 1 as id",
+        "mart_src": "{{ config(materialized='table') }}\n"
+                    "select count(*) as n from {{ ref('ext_src') }}",
+    }, on_run_start="{{ register_upstream_external_models() }}")
+    assert _dbt(proj, "run").success
+
+    # Fresh process, downstream model only: `ext_src` is never rebuilt, so the hook is the only
+    # thing that can make ref('ext_src') resolve.
+    out = subprocess.run(
+        [sys.executable, "-m", "dbt.cli.main", "run", "--select", "mart_src",
+         "--project-dir", str(proj), "--profiles-dir", str(proj)],
+        capture_output=True, text=True, env={**os.environ},
+    )
+    assert out.returncode == 0, out.stdout + out.stderr
+
+    con = duckrun.connect(root, schema="main", read_only=True)
+    assert con.sql("select n from mart_src").fetchall() == [(1,)]


### PR DESCRIPTION
Closes the last item on the "Gaps vs dbt-duckdb" list: `materialized='external'` errored on duckrun because dbt resolves a materialization by **exact adapter name** (only a `default` fallback, unlike `adapter.dispatch`), so dbt-duckdb's `adapter="duckdb"` macro was unreachable from `type: duckrun`.

### What this does

Ships dbt-duckdb's macro under duckrun's adapter name. That's the whole fix — every helper it calls arrives with `dependencies=['duckdb']`, and `external_root` / `external_write_options` / `external_read_location` are already `@available` on `DuckDBAdapter`.

Semantics are upstream's on purpose: `COPY … TO` writes a real parquet/csv/json file at `location` (default `<external_root>/<identifier>.<format>`) and the model becomes a view over that file. It is **not** aliased to Delta — `format: csv` has to give you a CSV, or a project shared with dbt-duckdb produces different bytes. `external_root` stays the only path rule; duckrun's `root_path` is uninvolved.

### The one deviation

The staging relation is dropped with a bare `drop table if exists` instead of dbt's `drop_relation`, which appends `CASCADE`. A python model is staged by `py_write_table` as an unparenthesized `create table … as select …` — the one form duckrun's cursor rewrites into a delta_rs write — so by drop time the relation is a `delta_scan` view, and the `CASCADE` form matches neither the DML router's `drop table` pattern nor a DuckDB view. Without it, both cases drop correctly. Commented at the site.

### How I know it works

New `tests/adapter/test_external.py`, all through real `dbt run`s (the `adapter` gate job):

- parquet round trip + a Delta `table` model reading it through `ref()`, and a second run (the rename/backup branch)
- csv and json, format explicit and inferred from the location extension
- `options: {partition_by: …}` → hive dirs on disk, globbed back through `ref()`
- empty model → the all-NULL sentinel row is filtered back out
- python external model
- **an external-only project writes no Delta at all** — the regression guard for duckrun's DML interception
- `register_upstream_external_models()` resolving an upstream external model in a genuinely separate process

`pytest tests/adapter` → 324 passed locally.

Docs: gap row removed from `limitations.md` (replaced by the two real caveats — the view is run-scoped, and `location` means *file* here), a new `external` section in `docs/dbt-adapter.md`, plus SKILL.md and CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
