### PR TITLE
release: 0.4.51

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "duckrun"
-version = "0.4.50"
+version = "0.4.51"
 description = "A dbt adapter that runs SQL in DuckDB and materializes to Delta Lake (delta_rs)."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Patch bump for the external materialization (#46).

`materialized='external'` now works on duckrun: a model can be exported as a plain parquet/csv/json file (DuckDB `COPY … TO`) and is surfaced as a view over that file. dbt-duckdb's macro, configs and defaults unchanged — it was only ever unreachable because dbt resolves materializations by exact adapter name.

pyproject bump only; tag `v0.4.51` follows on the squash commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)