### PR TITLE
test(layout): record the sort key AUTO actually picked, not the clause

### DIFF
--- a/tests/parquet_layout/aemo/build_auto_sort.py
+++ b/tests/parquet_layout/aemo/build_auto_sort.py
@@ -32,11 +32,11 @@ if OPT_TFS_MB is not None:
     from dbt.adapters.duckrun import engine as _engine
     _engine._TARGET_FILE_SIZE = OPT_TFS_MB * 1024 * 1024
     print(f"OPT_TFS_MB: target file size pinned to {OPT_TFS_MB} MB for this build", flush=True)
-# OPT_PAGE_ROWS: raise the data-page ROW cap (default 20k, see engine._DATA_PAGE_ROW_LIMIT) — the
-# page-granularity A/B vs the V-Order reference: its parquet-mr pages are ~1 MB / ~775k rows
-# (~61 data pages per 47M-row chunk) where duckrun's 20k-row cap makes ~2,350. With the cap
-# raised the 1 MB byte limit binds instead, landing pages at parquet-mr's shape. Same call-time
-# module-global seam as OPT_TFS_MB.
+# OPT_PAGE_ROWS: pin the data-page ROW cap (default 1M since d0d23b4, see
+# engine._DATA_PAGE_ROW_LIMIT) — the page-granularity A/B vs the V-Order reference, whose parquet-mr
+# pages are ~1 MB / ~775k rows (~61 data pages per 47M-row chunk). At the old 20k cap duckrun made
+# ~2,350 of them; at 1M the 1 MB byte limit binds instead and pages land at parquet-mr's shape.
+# Lower it here to reproduce the old geometry. Same call-time module-global seam as OPT_TFS_MB.
 _pr = os.environ.get("OPT_PAGE_ROWS", "").strip()
 OPT_PAGE_ROWS = int(_pr) if _pr.isdigit() and int(_pr) > 0 else None
 if OPT_PAGE_ROWS is not None:
@@ -65,24 +65,50 @@ def _exists():
         return False
 
 
+def resolved_sort_key(body):
+    """The COLUMNS `clause` resolves to — so the report names the key rather than the string
+    "sorted by auto".
+
+    Without this the only record of what the picker chose is a log line, and a build that quietly
+    picks a different key produces a byte-for-byte identical report; working out that a 592M-row
+    nyc table had swapped one measure for another in the last tail slot took byte forensics across
+    four runs. This is the whole point of the comparison, so it belongs in the record.
+
+    Resolved with the same two calls `session._resolve_auto_sort` makes. It deliberately does NOT
+    substitute an explicit `sorted by (<cols>)` for `auto` in the CTAS: `_resolve_auto_sort` also
+    runs `_narrow_wide_decimals`, and it returns EARLY for any non-AUTO sort, so pinning the columns
+    here would silently drop the wide-DECIMAL narrowing (~1 GB and a 10x cold cliff on Contoso's
+    price columns). The cost is therefore one extra profiling pass, and it is sound only because the
+    profiling sample is seeded (#48): this resolve and the CTAS's own resolve draw the same sample
+    and so agree. Before that fix they could legitimately differ and this would have been a lie."""
+    if sort.lower() != "auto":
+        return [c.strip() for c in sort.split(",") if c.strip()]
+    tbl = con._auto_sort_single_table(body)
+    return (con._auto_sort_cols_from_table(tbl) if tbl is not None
+            else con._auto_sort_cols(con.con.sql(body)))
+
+
 _t0 = time.perf_counter()
+sort_key = None
 if not force and _exists():
     rows = con.sql("select count(*) from tests.fct_summary_auto_sort").fetchone()[0]
     print(f"tests.fct_summary_auto_sort already exists ({rows:,} rows) — skipping "
           "(rebuild=true to rebuild)", flush=True)
-    status = "skipped"
+    status = "skipped"   # nothing was written, so no key was chosen — report null, not a guess
 else:
+    body = f"select * from {_src}"
+    sort_key = resolved_sort_key(body)
+    print(f"sort key: {clause} -> {sort_key or '(no sort — nothing pays off)'}", flush=True)
     print(f"Building tests.fct_summary_auto_sort with '{clause}' ...", flush=True)
     # Read mart.fct_summary directly (independent of the Spark V-Order build's read); SORTED BY AUTO
     # re-sorts regardless of the source's order.
-    con.sql(f"create or replace table tests.fct_summary_auto_sort {clause} "
-            f"as select * from {_src}")
+    con.sql(f"create or replace table tests.fct_summary_auto_sort {clause} as {body}")
     rows = con.sql("select count(*) from tests.fct_summary_auto_sort").fetchone()[0]
     print(f"done — tests.fct_summary_auto_sort built ({rows:,} rows)", flush=True)
     status = "rebuilt"
 
 report.merge({"tables": {"fct_summary_auto_sort": {"build": {
-    "engine": "delta_rs", "sort": clause, "vorder": False,
+    "engine": "delta_rs", "sort": clause, "sort_key": sort_key, "vorder": False,
     "row_group_ceiling": OPT_RG,     # None = adaptive (the default sizing)
     "target_file_size_mb": OPT_TFS_MB,  # None = the 256 MB default
     "seconds": round(time.perf_counter() - _t0, 1), "status": status}}}})

--- a/tests/parquet_layout/aemo/render_report.py
+++ b/tests/parquet_layout/aemo/render_report.py
@@ -245,9 +245,15 @@ _LAYOUT_COLS = ["table", "writer", "sort", "rows", "files", "row groups", "avg R
 
 
 def _sort_label(rep, t):
-    """The `sort` cell. Prefer build metadata (the actual columns AUTO picked); else the layout's
-    definitional intent, so auto_sort never shows an empty sort against its own name."""
+    """The `sort` cell. Prefer the RESOLVED key — the actual columns AUTO picked, which is the one
+    thing this comparison exists to show and which `sort` alone never carried (it is the requested
+    clause, so an AUTO build rendered as the literal "sorted by auto"). Fall back to that clause,
+    then to the layout's definitional intent, so auto_sort never shows an empty sort against its own
+    name. `sort_key` is `None` when nothing was built this cycle and `[]` when the picker declined."""
     b = rep.get("tables", {}).get(t, {}).get("build", {})
+    key = b.get("sort_key")
+    if key is not None:
+        return "sorted by (" + ", ".join(key) + ")" if key else "no sort (nothing paid off)"
     if b.get("sort"):
         return b["sort"]
     suf = t.removeprefix("fct_summary_")

--- a/tests/parquet_layout/contoso/build_auto_sort.py
+++ b/tests/parquet_layout/contoso/build_auto_sort.py
@@ -41,20 +41,36 @@ def _exists():
         return False
 
 
+def resolved_sort_key(body):
+    """The COLUMNS `clause` resolves to — see the AEMO build_auto_sort.py this mirrors for why the
+    report needs the key and not just the string "sorted by auto", and why this resolves the key
+    separately instead of substituting an explicit `sorted by (<cols>)` into the CTAS (doing that
+    would skip `_narrow_wide_decimals`, which is worth ~1 GB and a 10x cold cliff on exactly this
+    benchmark's price columns)."""
+    if sort.lower() != "auto":
+        return [c.strip() for c in sort.split(",") if c.strip()]
+    tbl = con._auto_sort_single_table(body)
+    return (con._auto_sort_cols_from_table(tbl) if tbl is not None
+            else con._auto_sort_cols(con.con.sql(body)))
+
+
 _t0 = time.perf_counter()
+sort_key = None
 if not force and _exists():
     rows = con.sql("select count(*) from tests.sales_auto_sort").fetchone()[0]
     print(f"tests.sales_auto_sort already exists ({rows:,} rows) — skipping "
           "(rebuild=true to rebuild)", flush=True)
-    status = "skipped"
+    status = "skipped"   # nothing was written, so no key was chosen — report null, not a guess
 else:
+    body = f"select * from {_src}"
+    sort_key = resolved_sort_key(body)
+    print(f"sort key: {clause} -> {sort_key or '(no sort — nothing pays off)'}", flush=True)
     print(f"Building tests.sales_auto_sort with '{clause}' ...", flush=True)
-    con.sql(f"create or replace table tests.sales_auto_sort {clause} "
-            f"as select * from {_src}")
+    con.sql(f"create or replace table tests.sales_auto_sort {clause} as {body}")
     rows = con.sql("select count(*) from tests.sales_auto_sort").fetchone()[0]
     print(f"done — tests.sales_auto_sort built ({rows:,} rows)", flush=True)
     status = "rebuilt"
 
 report.merge({"tables": {"sales_auto_sort": {"build": {
-    "engine": "delta_rs", "sort": clause, "vorder": False,
+    "engine": "delta_rs", "sort": clause, "sort_key": sort_key, "vorder": False,
     "seconds": round(time.perf_counter() - _t0, 1), "status": status}}}})

--- a/tests/parquet_layout/contoso/render_report.py
+++ b/tests/parquet_layout/contoso/render_report.py
@@ -238,8 +238,14 @@ _LAYOUT_COLS = ["table", "writer", "sort", "rows", "files", "row groups", "avg R
 
 
 def _sort_label(rep, t):
-    """The `sort` cell. Prefer build metadata; else the layout's definitional intent."""
+    """The `sort` cell. Prefer the RESOLVED key (the columns AUTO actually picked) over the
+    requested clause, which renders an AUTO build as the literal "sorted by auto" and hides the one
+    thing the comparison is for. `sort_key` is `None` when nothing was built this cycle and `[]`
+    when the picker declined; else the layout's definitional intent."""
     b = rep.get("tables", {}).get(t, {}).get("build", {})
+    key = b.get("sort_key")
+    if key is not None:
+        return "sorted by (" + ", ".join(key) + ")" if key else "no sort (nothing paid off)"
     if b.get("sort"):
         return b["sort"]
     suf = t.removeprefix("sales_")


### PR DESCRIPTION
Follow-up to #48.

## The problem

The layout harness compares a duckrun-sorted table against the V-Order reference — but it never recorded **which key the picker chose**. `build_auto_sort.py` stored:

```python
report.merge({"tables": {...: {"build": {"engine": "delta_rs", "sort": clause, ...}}}})
```

where `clause` is the literal string `"sorted by auto"`. And `render_report._sort_label`'s docstring already claimed it rendered *"the actual columns AUTO picked"* while actually rendering that string.

So two builds that picked **different keys** produced byte-identical reports. Establishing that a 592M-row nyc table had swapped `fare_amount` for `tip_amount` in its last tail slot took byte forensics across four runs — the key existed only in a log line.

## The change

Resolve the key with the same two calls `session._resolve_auto_sort` makes, and store it as `sort_key`:

```python
tbl = con._auto_sort_single_table(body)
return (con._auto_sort_cols_from_table(tbl) if tbl is not None
        else con._auto_sort_cols(con.con.sql(body)))
```

Renderers prefer it over the clause. Applied to both aemo and contoso, which are explicit mirrors of each other.

| report state | renders as |
|---|---|
| `sort_key: ["date","time","price"]` | `sorted by (date, time, price)` |
| `sort_key: []` (picker declined) | `no sort (nothing paid off)` |
| `sort_key: None` (build skipped) | falls back to `sorted by auto` |
| field absent (existing report JSONs) | falls back to `sorted by auto` |

All six branches exercised locally against `_sort_label`.

## Why it resolves separately instead of pinning the columns

The cheaper way to learn the key would be to substitute an explicit `sorted by (<cols>)` for `auto` in the CTAS. **That would be a silent regression:** `_resolve_auto_sort` also runs `_narrow_wide_decimals`, and it returns early for any non-AUTO sort — so pinning the columns drops the wide-DECIMAL narrowing, worth ~1 GB and a 10× cold cliff on exactly Contoso's price columns.

The cost is therefore one extra profiling pass, and it is **only sound because of #48**: this resolve and the CTAS's own resolve draw the same seeded sample and so agree. Before that fix they could legitimately differ and the reported key would have been a lie.

## Also

Drops the stale 20k data-page row cap from the `OPT_PAGE_ROWS` comment — `d0d23b4` raised `_DATA_PAGE_ROW_LIMIT` to 1M.

## Testing

Renderer branches verified locally; `py_compile` clean on all four files. The harness itself can only run on `main` — the Entra federated identity credential is scoped to `refs/heads/main`, so a branch dispatch fails at OIDC before touching Fabric (`AADSTS700213`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
