### PR TITLE
release: 0.4.52

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "duckrun"
-version = "0.4.51"
+version = "0.4.52"
 description = "A dbt adapter that runs SQL in DuckDB and materializes to Delta Lake (delta_rs)."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Sort-key picker fixes (#48, #50) plus layout-harness observability (#49).

## What changed

**`sort_by: auto` is deterministic** (#48). The profiling sample was unseeded — `auto_sort_cols` only emitted `REPEATABLE` when a caller passed a seed, and no production caller does. One unchanged config could pick a different key on every build: four runs on one adapter version over an identical 592M-row table split 3/1 on which measure won the last tail slot, an **8.8% / 700 MB** spread from sample luck.

**R5 decides on exact counts inside the noise zone** (#50). The rule that drops functionally-dependent columns compared two HLL sketches against a 12% band. For a true dependency that ratio is exactly 1.0 — but the sketch is worth ±10–25% at the cardinality real dimensions live at, so measured ratios ranged 0.88–1.48. A strict FD read as independent: a real aemo build picked `date, year, time`, where `year` is a calendar join on `date`. Now the sketch screens and one exact count per candidate decides, only near the grain.

**The measure tail measures in-group cardinality on whole groups** (#50). A tail slot asks how many distinct values a measure takes *inside* a dim group — the one question a uniform row sample can't answer once the dim key is fine. The aemo mart is 142M rows over ~2.6M `(date,time)` groups against an 8M-row sample: 3.1 rows per group, so every measure looked unique and no tail was ever awarded. It now reads whole groups from the source (~1.4% of the table, one bounded pass) when the sample is too thin.

`MODEL_VERSION` 3 → 4, so a recommendation stays attributable to the model that produced it.

## Measured on the real 142M-row aemo mart

| | key | size |
|---|---|---|
| before | `date, year, time` | — |
| after | **`date, time, price`** | **567.22 MB** |
| Spark V-Order reference | — | 765.26 MB |

26% smaller than Fabric's own writer, same 142M rows, same SNAPPY.

## Regression risk — stated plainly

This changes key selection for **every** dataset, and it is validated end-to-end on **one** (aemo). The unit suite covers the mechanics across cardinalities and both failure directions, but "does the new key beat the old one" is measured on aemo alone.

Two things bound the risk:

- Both changes make the picker's inputs *more accurate*, not more aggressive. R5 drops a column only when exact counts confirm the dependency; the tail awards a slot only when whole-group counts show real in-group structure. A wrong answer now requires the exact numbers to be wrong.
- The tail path is gated on `_GROUP_STARVED_FRAC` and degrades to the old sample-only behaviour whenever the source isn't reachable or the sample already covers groups densely — so densely-sampled tables take the same path they did before.

What is *not* covered: nyc, bts, cms and green have no layout run on this code. `dax=false, rebuild=false` now makes checking any of them a ~2-minute, no-CU dispatch — worth doing for cms in particular (91 columns, the widest key-selection surface in the corpus).

## Gate

Full suite per the release gate — cores + conformance + local-stress. Locally: 344 passed, 1 skipped across `tests/sortkey`, `tests/dbt_unit_tests`, `tests/connection_api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
