### PR TITLE
release: 0.4.54

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "duckrun"
-version = "0.4.53"
+version = "0.4.54"
 description = "A dbt adapter that runs SQL in DuckDB and materializes to Delta Lake (delta_rs)."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Patch bump for the one-row-group-per-file change landed in #55. `pyproject.toml` only, per the release convention — `[Unreleased]` in the CHANGELOG stays put.

Tag `v0.4.54` goes on the squash-merge commit of this PR, which triggers `publish.yml` (gated on cores + conformance + local-stress/merge-spill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)