### PR TITLE
fix(sortkey): de-thin substrate run counts before pricing the tail (model v9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,16 @@ All notable changes to this project will be documented in this file.
     production. The measure tail's group-stratified source read is deleted with the sample that
     forced it: over every row, `distinct(prefix, measure)` *is* the measure's run count.
   - Cost moves from remote I/O to local disk — the staged copy spills to `temp_directory`.
+- **Above ~30M rows the picker profiles a bounded deterministic substrate** (sort-key models
+  `v6`–`v9`). v5's every-row profile cost passes × table size — measured 49 minutes of a 72-minute
+  592M-row build — so profiling now reads only the rows whose whole-row hash lands in one of K
+  residue classes (~30M rows kept; no seed, no order dependence; `DUCKRUN_PROFILE_ROWS` moves the
+  cap, `0` disables it), and uniqueness claims are suppressed again above the cap (`v6`). On a
+  substrate the measure tail is priced at full scale (`v7`), near-tied tail argmaxes are settled on
+  exact counts over the substrate (`v8`), and substrate run counts are de-thinned through the
+  survival model `1-(1-p)^m` before pricing (`v9`) — 1-in-K thinning starves a many-small-combos
+  measure's distinct count far more than a thick-combo peer's, which had been handing the tail slot
+  to the wrong money column.
 - **`sort_by: 'auto'` no longer profiles on write paths that discard the key.** Resolving `'auto'`
   means profiling the staged model result — the expensive part of the feature — but `sort_by` is a
   DuckDB `ORDER BY` applied to the relation the write reads, and three branches never read it: the

--- a/dbt/adapters/duckrun/sortkey.py
+++ b/dbt/adapters/duckrun/sortkey.py
@@ -92,6 +92,29 @@ def substrate_modulus(n):
     return -(-int(n) // SUBSTRATE_CAP)
 
 
+def de_thin_runs(runs_sub, profile_rows, total_rows):
+    """Full-scale distinct-combo count recovered from a substrate count. A combo holding m
+    full-scale rows survives 1-in-K thinning with probability 1-(1-p)**m (p = profile/total),
+    so small combos vanish while thick ones survive — the asymmetry that flipped contoso's
+    tail argmax (see the v9 changelog). Inverting needs m, and m = total/runs_full needs the
+    answer, so a short fixed point: seed runs_full = runs_sub, then runs_full = runs_sub /
+    (1-(1-p)**m). The iterate is monotone increasing and bounded (m >= 1 keeps survival >= p,
+    so r <= runs_sub/p); four rounds settle the thick-combo regime and merely under-correct —
+    the conservative direction — as combos thin toward singletons. Identity when the profile
+    is exact. Pure, like substrate_modulus, so the arithmetic is unit-testable without a
+    table."""
+    if not total_rows or not profile_rows or total_rows <= profile_rows or runs_sub <= 0:
+        return runs_sub
+    p = float(profile_rows) / float(total_rows)
+    r = float(runs_sub)
+    for _ in range(4):
+        surv = 1.0 - (1.0 - p) ** max(1.0, float(total_rows) / r)
+        if surv <= 0.0:              # p underflowed to 0.0 — cannot invert, stay at the floor
+            break
+        r = float(runs_sub) / surv
+    return min(max(r, float(runs_sub)), float(total_rows))
+
+
 # How many exact-skew columns share one GROUPING SETS scan. Internal batching width, not a policy
 # knob: each set is its own ≤_SKEW_EXACT_NDV-group hash table inside ONE pass over the source, so
 # the ceiling is per-scan aggregate state (8 × 100k groups is trivial), and the win is passes — on
@@ -131,7 +154,17 @@ _SKEW_SETS_PER_SCAN = 8
 #     decided on EXACT counts over the substrate (one extra scan, tied levels only). v7 restored
 #     the tail but the sketch flipped contoso's near-tied UnitPrice/NetPrice argmax (1785 vs the
 #     full profile's 1686-MB UnitPrice pick). Full-profile behavior unchanged.
-MODEL_VERSION = "8"
+# v9: the substrate tail's runs are DE-THINNED before pricing. v7 transferred the substrate's
+#     distinct count to full-scale prices raw, but thinning is not uniform across candidates: a
+#     combo with m full-scale rows survives 1-in-K thinning with probability 1-(1-p)^m, so a
+#     many-small-combos measure loses far more of its count than a thick-combo peer, deflating
+#     exactly its RLE bytes and inflating its save. v8's exact tie-break proved the resulting
+#     argmax flip is thinning itself, not sketch noise (contoso: NetPrice over UnitPrice on
+#     exact substrate counts too — 1784 vs 1686 MB). `de_thin_runs` inverts the survival model
+#     by fixed point wherever `save` is priced — sketch path and exact tie-break alike; the FD
+#     screens, t_grain and the output rows stay in substrate units (like compared with like).
+#     Full-profile behavior unchanged: de-thin is the identity on an exact profile.
+MODEL_VERSION = "9"
 
 # R5's FD ratio SCREENS on HLL and DECIDES on exact counts below this multiple of the kept grain.
 # `approx_count_distinct` is a sketch, and at the NDV where real dimensions live (10²–10⁵) it is
@@ -651,6 +684,9 @@ def recommend_sort_key(con, sch, tbl, src, cols, types, partition_cols,
         # conservative full-scale estimate (an undercount only overstates the save — the cheap
         # direction, since a kept junk tail costs sort time while a lost tail costs the money
         # column). Not sampled → t_n = n and this block is byte-identical to the v5 arithmetic.
+        # The undercount is NOT uniform across candidates, though — small combos vanish under
+        # thinning while thick ones survive — so since v9 the transfer runs through
+        # `de_thin_runs` first (see the changelog).
         t_n = float(total_rows) if sampled else float(n)
         t_cnt_bits = max(1, math.ceil(math.log2(t_n))) if t_n > 1 else 1
 
@@ -703,7 +739,10 @@ def recommend_sort_key(con, sch, tbl, src, cols, types, partition_cols,
                 if runs < t_grain * (1.0 + fd_band):
                     t_remaining.remove(c)
                     continue
-                save = t_iid[c] - _t_bytes(c, runs)
+                # v9: de-thin before pricing — thinning is not uniform across candidates
+                # (survival 1-(1-p)^m), so a raw substrate count deflates a small-combo
+                # candidate's RLE bytes more than a thick-combo peer's (see de_thin_runs).
+                save = t_iid[c] - _t_bytes(c, de_thin_runs(runs, n, t_n))
                 scored.append((save, runs, c))
                 if save > best_save:
                     best, best_runs, best_save = c, runs, save
@@ -716,7 +755,7 @@ def recommend_sort_key(con, sch, tbl, src, cols, types, partition_cols,
                     best, best_runs, best_save = None, None, 0.0
                     for c in [c for _s, _r, c in scored if c in ex]:   # stable candidate order
                         runs = ex[c]
-                        save = t_iid[c] - _t_bytes(c, runs)
+                        save = t_iid[c] - _t_bytes(c, de_thin_runs(runs, n, t_n))
                         if save > best_save:
                             best, best_runs, best_save = c, runs, save
             if (best is None

--- a/tests/sortkey/test_sortkey_properties.py
+++ b/tests/sortkey/test_sortkey_properties.py
@@ -705,6 +705,24 @@ def test_substrate_modulus_gate(monkeypatch):
     assert sortkey.substrate_modulus(10**12) == 1                         # kill switch: always exact
 
 
+def test_de_thin_runs_inverts_the_survival_model():
+    # identity off-substrate (full profile, missing total) and on degenerate inputs
+    assert sortkey.de_thin_runs(5000, 200_000, None) == 5000
+    assert sortkey.de_thin_runs(5000, 200_000, 200_000) == 5000
+    assert sortkey.de_thin_runs(0, 28_571, 200_000) == 0
+    # exact inversion on uniform combos: 10,000 combos of 20 rows at p=1/7 thin to
+    # 10,000*(1-(1-p)^20) ≈ 9,541 — four fixed-point rounds recover 10,000 within 1%
+    p = 28_571 / 200_000
+    thinned = 10_000 * (1.0 - (1.0 - p) ** 20)
+    assert sortkey.de_thin_runs(thinned, 28_571, 200_000) == pytest.approx(10_000, rel=0.01)
+    # monotone in runs_sub; clamped to [runs_sub, total_rows]; the near-distinct degenerate
+    # end (runs_sub == profile rows has no finite fixed point) never diverges past the clamp
+    a = sortkey.de_thin_runs(9_541, 28_571, 200_000)
+    b = sortkey.de_thin_runs(23_000, 28_571, 200_000)
+    assert 9_541 <= a < b <= 200_000
+    assert sortkey.de_thin_runs(28_571, 28_571, 200_000) <= 200_000
+
+
 def test_sampled_profile_suppresses_uniqueness():
     """Above the cap the profile is a substrate, and a substrate can overclaim column uniqueness
     (a value duplicated across rows can land in different hash buckets) — so is_unique must never
@@ -803,3 +821,34 @@ def test_sampled_tail_tie_decided_on_exact_counts():
                                             total_rows=200_000)
     assert _key(full) == ["grp", "price"], _key(full)
     assert _key(samp) == _key(full), "the substrate's tie-break must match the full profile"
+
+
+def test_sampled_tail_argmax_is_de_thinned_before_pricing():
+    """Model v9: thinning is not uniform across candidates — a combo with m full-scale rows
+    survives 1-in-K thinning with probability 1-(1-p)^m, so netprice's 4-row combos lose ~54%
+    of their distinct count under 1-in-7 thinning while price's 20-row combos lose ~5%. Priced
+    raw at full scale (v7), the deflated count shrinks exactly netprice's RLE bytes and hands
+    it the slot — and v8's exact counts agree, because the distortion IS the thinning, not the
+    sketch (contoso: NetPrice over UnitPrice, 1784 vs 1686 MB). de_thin_runs inverts the
+    survival model wherever `save` is priced. Fixture: price repeats in 20-row stretches
+    (thick, survival ~0.95), netprice in 4-row stretches (thin, survival ~0.46); both scales
+    must rank price first and then keep netprice as the second tail slot — on v8 the substrate
+    instead commits netprice and FD-bins price (each 4-block determines its 20-block).
+    Verified red on model v8: the substrate leg returned ['grp', 'netprice']."""
+    con = duckdb.connect()
+    con.execute("CREATE OR REPLACE TABLE dt AS "
+                "select (i // 1000)::int as grp, ((i // 20) % 2000)::double as price, "
+                "((i // 4) % 50000)::double as netprice, "
+                "(i % 977)::int as fill from range(200000) t(i)")
+    desc = con.sql("DESCRIBE dt").fetchall()
+    cols, types = [r[0] for r in desc], {r[0]: r[1] for r in desc}
+
+    def _key(rows):
+        return [r[3] for r in sorted((x for x in rows if x[1]), key=lambda x: x[2])]
+
+    full, _, _ = sortkey.recommend_sort_key(con, "s", "dt", "dt", cols, types, [])
+    assert _key(full) == ["grp", "price", "netprice"], _key(full)
+    con.execute("CREATE OR REPLACE TEMP TABLE dtsub AS SELECT * FROM dt _r WHERE hash(_r) % 7 = 0")
+    samp, _, _ = sortkey.recommend_sort_key(con, "s", "dt", "dtsub", cols, types, [],
+                                            total_rows=200_000)
+    assert _key(samp) == _key(full), "the de-thinned argmax must match the full profile (model v9)"


### PR DESCRIPTION
## Problem

Shipped-with-0.4.56 gap: on contoso (142M rows, above the 30M substrate cap) the substrate profile puts **NetPrice** in the measure-tail slot where the full profile picks **UnitPrice** — 1784 MB vs the 1686 MB baseline, 3% above the reference layout instead of 2.6% under it.

Root cause (each layer verified by a dispatch): v7 prices the tail at full scale but feeds it the raw substrate-scale `runs`. Thinning is not uniform across candidates — a combo holding `m` full-scale rows survives 1-in-K thinning with probability `1-(1-p)^m` (`p = profile/total`), so a many-small-combos measure (NetPrice, ~4-row combos) loses far more of its distinct count than a thick-combo peer (UnitPrice, ~20-row combos), deflating exactly its RLE bytes and inflating its modeled save. v8's exact tie-break proved the flip is the thinning itself, not sketch noise: exact substrate counts still rank NetPrice first.

## Fix (model v9)

`de_thin_runs(runs_sub, profile_rows, total_rows)` — a pure module-level helper that inverts the survival model with a 4-round fixed point (`runs_full = runs_sub / (1-(1-p)^m)`, `m = total/runs_full`; monotone, bounded, clamped to `[runs_sub, total_rows]`). Applied at the two points where `save` is priced: the sketch/confirm path and the v8 exact tie-break.

Deliberately unchanged: the FD screens, `t_grain`, and the output rows stay in substrate units (like compared with like); the dim loop is untouched (K cancels in its ratios). The helper is the identity on an exact profile, so **full-profile behavior is byte-identical** — generic arithmetic, nothing tuned to any dataset.

## Tests

- Unit test of `de_thin_runs`: identity off-substrate, exact inversion on uniform combos (recovers 10,000 from ~9,541 within 1%), monotonicity, clamps.
- Contoso-shaped integration fixture (20-row combos vs 4-row combos under a 1-in-7 substrate): **verified red on v8** (substrate returned `['grp', 'netprice']`) and green on v9 (both scales agree on `['grp', 'price', 'netprice']`).
- All 53 sortkey property tests pass; byte-exact full-profile goldens and the 12-scan budget are untouched.

## Post-merge validation

Layout benchmark runs on main only (OIDC): one contoso dispatch (`benchmark=contoso dax=false rebuild=true`) — expect the key to end `…, Quantity, UnitPrice` at ~1686 MB ≤ 1731.9 — then aemo + nyc dispatches (fat tail margins / full profile: expect no movement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)