### PR TITLE
release: 0.4.57 - de-thinned substrate tail pricing (sort-key model v9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "duckrun"
-version = "0.4.56"
+version = "0.4.57"
 description = "A dbt adapter that runs SQL in DuckDB and materializes to Delta Lake (delta_rs)."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump only. Ships #58 (sort-key model v9: de-thin substrate run counts before pricing the measure tail).

Layout validation on main at b3d26b7:

| dataset | v8 (0.4.56) | v9 | reference |
|---|---|---|---|
| contoso | 1784 MB, wrong money tail (NetPrice) | **1692.02 MB**, `…, Quantity, UnitPrice` | 1731.9 MB |
| aemo | 567.21 MB, `date, time, price` | **549.43 MB**, `date, time, price, mw` | 765.26 MB |
| nyc | 6483 MB / 43 files | **6056 MB** / 40 files | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)