### PR TITLE
perf(snapshot): materialize the merge source once; skip zero-row merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **An unchanged snapshot no longer spends minutes evaluating a source the merge never touches**
+  (issue #61). The snapshot materialization now forwards `merge_materialize_source: true`: its merge
+  source was a lazy view stack (staging over a pinned remote `delta_scan` plus the model SQL) that
+  the cardinality guard and delta-rs's source collection each re-evaluated end to end — ~40 s of a
+  reported 122 s run re-reading remote data the merge then didn't use — and, because dbt's staging
+  stamps `now()` into the SCD2 columns, each evaluation produced *different* rows than the ones the
+  guards had vouched for. The source is now staged once into a local temp table and every merge
+  phase reads that one materialization. On top of that, when a materialized source stages **zero
+  rows** (nothing changed) the engine now skips the merge machinery outright — the target open and
+  version pin, delta-rs's source collection and join build, and the post-merge maintenance
+  (delta-rs already declined to *commit* an empty merge, but only after paying all of that). The
+  short-circuit applies to any merge whose source duckrun materialized (`merge_materialize_source`
+  or a `not_null` contract), never to a lazy source, and stands aside for
+  `WHEN NOT MATCHED BY SOURCE` clauses — an empty source matches every target row there.
+  `on_schema_change` still lands a new column carried by a zero-row source.
+
 ### Added
 - **`materialized='external'`** — the last materialization dbt-duckdb had and duckrun didn't. A
   model can now be exported as a plain parquet/csv/json file (DuckDB `COPY … TO`) and is surfaced as

--- a/dbt/adapters/duckrun/delta_plugin.py
+++ b/dbt/adapters/duckrun/delta_plugin.py
@@ -681,6 +681,7 @@ class Plugin(BasePlugin):
                     max_spill_size=cfg.get("merge_max_spill_size"),
                     max_temp_directory_size=cfg.get("merge_max_temp_directory_size"),
                     streamed_exec=(False if sx is None else bool(sx)),
+                    source_materialized=src_tmp is not None,
                     read_version=cfg.get("read_version"),
                     partition_by=cfg.get("partition_by"),
                     sort_by=cfg.get("sort_by"),
@@ -705,6 +706,7 @@ class Plugin(BasePlugin):
                     max_spill_size=cfg.get("merge_max_spill_size"),
                     max_temp_directory_size=cfg.get("merge_max_temp_directory_size"),
                     streamed_exec=(False if sx is None else bool(sx)),
+                    source_materialized=src_tmp is not None,
                     # Pin the merge target to the version the model read (vB, captured before it
                     # read {{ this }}), so OCC validates (vB, HEAD] — read and commit are one snapshot.
                     read_version=cfg.get("read_version"),

--- a/dbt/adapters/duckrun/engine.py
+++ b/dbt/adapters/duckrun/engine.py
@@ -2149,6 +2149,7 @@ def merge_delta(
     max_spill_size: Optional[int] = None,
     max_temp_directory_size: Optional[int] = None,
     streamed_exec: bool = False,
+    source_materialized: bool = False,
     read_version: Optional[int] = None,
     delete_unmatched_by_source=None,
     storage_options: Optional[Dict[str, str]] = None,
@@ -2204,6 +2205,12 @@ def merge_delta(
       collecting a small delta is cheap and the prune avoids a full-target scan. For a merge whose
       *source* is itself huge, pass streamed_exec=True (``merge_streamed_exec``) so it isn't
       materialized — at the cost of no pruning.
+    - source_materialized: tell the merge that ``data`` reads a table the caller already
+      materialized (the dbt plugin's temp-table staging), i.e. probing it is cheap and stable.
+      Enables the empty-source short-circuit in ``merge_delta_clauses``: a zero-row source with no
+      by-source clause skips the merge machinery (target open + pin, source collection, post-merge
+      maintenance) outright. Never set it for a lazy relation — the probe would re-evaluate the
+      model.
     - delete_unmatched_by_source: the "WHEN NOT MATCHED BY SOURCE THEN DELETE" form — also remove
       target rows the source doesn't carry. True deletes every unmatched target row (full sync); a
       string deletes only those matching that predicate; None (default, used by the dbt incremental
@@ -2253,6 +2260,7 @@ def merge_delta(
         merge_schema=merge_schema,
         existing_columns=existing_columns,
         streamed_exec=streamed_exec,
+        source_materialized=source_materialized,
         max_spill_size=max_spill_size,
         max_temp_directory_size=max_temp_directory_size,
         storage_options=storage_options,
@@ -2780,6 +2788,7 @@ def merge_delta_clauses(
     merge_schema: bool = False,
     existing_columns: Optional[List[str]] = None,
     streamed_exec: bool = False,
+    source_materialized: bool = False,
     max_spill_size: Optional[int] = None,
     max_temp_directory_size: Optional[int] = None,
     storage_options: Optional[Dict[str, str]] = None,
@@ -2855,6 +2864,24 @@ def merge_delta_clauses(
     _merge_cardinality_guard(data, predicate, clauses, streamed_exec)
     effective_version = _merge_evolve_schema(path, data, storage_options, read_version,
                                              merge_schema, existing_columns=existing_columns)
+
+    # Empty-source short-circuit (issue #61): a merge whose source has no rows touches no target
+    # row, so skip the whole merge machinery — the target open + version pin, delta_rs's source
+    # collection and join build, the merge gate, and the post-merge maintenance. (delta_rs itself
+    # declines to COMMIT an empty merge, but only after paying all of that — remote round-trips an
+    # unchanged snapshot re-run pays for nothing.) Only when the caller MATERIALIZED the source
+    # (``source_materialized`` — the dbt plugin's temp-table staging): probing it is then one
+    # LIMIT 1 off a local table, and the answer describes the same rows the merger would collect.
+    # A lazy source is never probed — the probe could cost a full model evaluation, and a
+    # nondeterministic model could answer "empty" for rows the merger would then see (the #14
+    # hazard). Placed AFTER the schema evolution so on_schema_change='append_new_columns' still
+    # lands a new column carried by a zero-row source, and skipped when a not_matched_by_source
+    # clause exists — for those an empty source matches EVERY target row: work, not a no-op.
+    if (source_materialized and hasattr(data, "limit")
+            and not any(c.get("clause") == "not_matched_by_source" for c in clauses)
+            and data.limit(1).fetchone() is None):
+        logger.info("merge: source has no rows and no by-source clause; nothing to do (no commit)")
+        return
 
     # Insert-only: divert to the DuckDB anti-join + plain append (see the docstring). Done AFTER the
     # cardinality guard and the decoupled schema evolution so both branches inherit them unchanged,

--- a/dbt/include/duckrun/macros/materializations/snapshot.sql
+++ b/dbt/include/duckrun/macros/materializations/snapshot.sql
@@ -119,12 +119,23 @@
          SnapshotConfig.on_schema_change defaults to 'ignore', so a passthrough would silently keep
          dropping columns. The added column is evolved as a metadata-only commit BEFORE the merge
          (engine.merge_delta_clauses), so it reads NULL on the already-closed version — the close row's
-         update touches only dbt_valid_to — matching dbt-core's default snapshot exactly. --#}
+         update touches only dbt_valid_to — matching dbt-core's default snapshot exactly.
+
+         merge_materialize_source is hardcoded true, like on_schema_change (issue #61). The merge
+         source here is a lazy view stack (merge_src -> staging -> pinned delta_scan + the model SQL),
+         and dbt's staging SQL stamps snapshot_get_time() = now() into dbt_updated_at/dbt_valid_from —
+         and, under the check strategy, into dbt_scd_id. Left lazy, every consumer (the cardinality
+         guard, delta_rs's source collection) re-runs that stack against remote storage AND computes
+         different timestamps per evaluation, so the guards vouch for rows that are not the ones
+         written (the #14 hazard). One temp-table staging pins the rows once — dbt's own default
+         snapshot materializes its staging as a real table for the same reason — and lets the engine
+         skip the merge entirely (no commit) when an unchanged source stages zero rows. --#}
     {% do adapter.store_relation('duckrun', merge_src, columns, location, 'delta', {
         'incremental': true,
         'incremental_strategy': 'merge',
         'unique_key': snapshot_cols.dbt_scd_id,
         'merge_update_columns': [snapshot_cols.dbt_valid_to],
+        'merge_materialize_source': true,
         'read_version': read_version,
         'dbt_believes_exists': true,
         'full_refresh': false,

--- a/tests/adapter/test_review_fixes.py
+++ b/tests/adapter/test_review_fixes.py
@@ -655,3 +655,105 @@ def test_narrow_wide_decimals_select_passthrough_without_wide_columns():
     con = duckdb.connect()
     con.execute("create table t as select i::DECIMAL(18,2) p, i n from range(10) t(i)")
     assert Plugin._narrow_wide_decimals_select(con, "t") == "SELECT * FROM t"
+
+
+# ------------------------------------------------ issue #61: empty-source merge short-circuit
+
+def test_snapshot_macro_materializes_the_merge_source():
+    """Issue #61, macro half: the snapshot materialization MUST forward
+    'merge_materialize_source': true. Its merge source is a lazy view stack whose staging SQL
+    stamps now() into the SCD2 columns, so every un-materialized consumer (cardinality guard,
+    delta_rs collection) re-runs the remote reads AND computes different rows per evaluation.
+    The reporter of #61 set the config on the snapshot and it silently went nowhere — pin the
+    forwarding the same way test_delta_core_macro_forwards_every_config_key_the_plugin_reads
+    pins _delta_core.sql's dict."""
+    from pathlib import Path
+
+    from dbt.adapters.duckrun import delta_plugin
+
+    macro = (Path(delta_plugin.__file__).parents[2] / "include" / "duckrun" / "macros"
+             / "materializations" / "snapshot.sql").read_text(encoding="utf-8")
+    # The merge-branch store_relation dict (the first-run branch overwrites; it has no merge).
+    block = macro.split("'incremental_strategy': 'merge'", 1)[1].split("}", 1)[0]
+    assert "'merge_materialize_source': true" in block, (
+        "snapshot.sql's merge store_relation dict no longer forwards "
+        "'merge_materialize_source': true — the snapshot merge source is lazy+nondeterministic "
+        "again (issue #61)"
+    )
+
+
+def _merge_target(tmp_path):
+    import pyarrow as pa
+
+    path = str(tmp_path / "t")
+    engine.write_delta(path, pa.table({
+        "id": pa.array([1, 2, 3], pa.int64()),
+        "value": pa.array([10, 20, 30], pa.int64()),
+    }), "overwrite")
+    return path
+
+
+def _empty_source(con):
+    return con.sql("SELECT 1::BIGINT AS id, 1::BIGINT AS value WHERE 1 = 0")
+
+
+def test_empty_materialized_source_merge_commits_nothing(tmp_path):
+    """The engine half of issue #61: a zero-row source the caller materialized upserts nothing,
+    so nothing is committed — no empty MERGE commit, no maintenance — and the version stays put
+    (an unchanged snapshot re-run must not grow the Delta log)."""
+    from deltalake import DeltaTable
+
+    path = _merge_target(tmp_path)
+    con = duckdb.connect()
+    engine.merge_delta(path, _empty_source(con), "id",
+                       source_materialized=True, read_version=0, cur=con)
+    dt = DeltaTable(path)
+    assert dt.version() == 0
+    assert dt.to_pyarrow_table().num_rows == 3
+
+
+def test_empty_lazy_source_still_runs_the_full_merge(tmp_path):
+    """source_materialized=False (the default — a lazy relation): probing could re-evaluate the
+    model, and a nondeterministic one could answer 'empty' for rows the merger would then see.
+    So no probe — the merge runs through delta_rs unchanged and the table stays correct. (delta_rs
+    itself declines to commit an empty merge, so the version stays put on BOTH paths; what the
+    short-circuit saves is the machinery — target open, version pin, source collection,
+    post-merge maintenance — not the commit.)"""
+    from deltalake import DeltaTable
+
+    path = _merge_target(tmp_path)
+    con = duckdb.connect()
+    engine.merge_delta(path, _empty_source(con), "id", read_version=0)
+    dt = DeltaTable(path)
+    assert dt.version() == 0
+    assert dt.to_pyarrow_table().num_rows == 3
+
+
+def test_empty_source_with_by_source_clause_still_merges(tmp_path):
+    """An empty source under WHEN NOT MATCHED BY SOURCE matches EVERY target row — work, not a
+    no-op. The short-circuit must stand aside and let the delete land."""
+    from deltalake import DeltaTable
+
+    path = _merge_target(tmp_path)
+    con = duckdb.connect()
+    engine.merge_delta(path, _empty_source(con), "id",
+                       source_materialized=True, delete_unmatched_by_source=True,
+                       read_version=0)
+    dt = DeltaTable(path)
+    assert dt.version() >= 1
+    assert dt.to_pyarrow_table().num_rows == 0
+
+
+def test_nonempty_materialized_source_upserts_normally(tmp_path):
+    """source_materialized with actual rows: the probe sees a row and the merge proceeds
+    unchanged — byte-identical upsert semantics."""
+    from deltalake import DeltaTable
+
+    path = _merge_target(tmp_path)
+    con = duckdb.connect()
+    src = con.sql("SELECT 3::BIGINT AS id, 999::BIGINT AS value "
+                  "UNION ALL SELECT 4::BIGINT, 40::BIGINT")
+    engine.merge_delta(path, src, "id", source_materialized=True, read_version=0)
+    t = DeltaTable(path).to_pyarrow_table().sort_by("id")
+    assert dict(zip(t.column("id").to_pylist(), t.column("value").to_pylist())) == \
+        {1: 10, 2: 20, 3: 999, 4: 40}

--- a/tests/conformance/test_simple_snapshot.py
+++ b/tests/conformance/test_simple_snapshot.py
@@ -204,3 +204,41 @@ class TestSnapshotSchemaEvolutionNoVersionChange:
         assert rows[0][0] == 10
         assert rows[0][1] is None
         assert rows[0][2] is True
+
+
+class TestUnchangedSnapshotCommitsNothing:
+    """Issue #61: re-running a snapshot whose source has not changed must not create a Delta
+    commit. The staging query yields zero rows; the materialized merge source makes that knowable
+    with one cheap probe, and the engine then skips the merge AND its post-merge maintenance —
+    the table's version stays put instead of the log growing (and every open slowing) with each
+    scheduled no-op run."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"snap_source.sql": _source_v1}
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {"col_snapshot.sql": _snapshot_sql}
+
+    def test_rerun_without_changes_leaves_the_version_alone(self, project, dbt_profile_target):
+        from deltalake import DeltaTable
+
+        run_dbt(["run"])
+        results = run_dbt(["snapshot"])
+        assert all(r.status == "success" for r in results)
+
+        path = f"{dbt_profile_target['root_path']}/{project.test_schema}/col_snapshot"
+        version_after_first_snapshot = DeltaTable(path).version()
+
+        # Source unchanged — the second snapshot run must succeed AND commit nothing.
+        results = run_dbt(["snapshot"])
+        assert all(r.status == "success" for r in results)
+        assert DeltaTable(path).version() == version_after_first_snapshot
+
+        # And the SCD2 content is untouched: one open version, nothing closed.
+        relation = relation_from_name(project.adapter, "col_snapshot")
+        counts = project.run_sql(
+            f"select count(*), count(dbt_valid_to) from {relation}", fetch="one"
+        )
+        assert tuple(counts) == (1, 0)


### PR DESCRIPTION
Fixes #61.

## Problem

An unchanged 35-row snapshot on OneLake took ~122 s, with the actual delta-rs merge at 0.03 s. The snapshot's merge source is a lazy view stack (`merge_src` → dbt's staging SQL → a pinned remote `delta_scan` + the model SQL), and every pre-merge phase re-evaluated it end to end:

- the merge cardinality guard (reported 30.95 s),
- delta-rs's source collection at builder time (9.86 s),

each re-reading remote Delta data. Worse than slow: dbt's staging stamps `snapshot_get_time()` = `now()` into `dbt_updated_at`/`dbt_valid_from` — and under the `check` strategy into `dbt_scd_id` — so each evaluation produced *different rows* than the ones the guard had vouched for (exactly the #14 hazard the plugin's `merge_materialize_source` comment describes; the snapshot path was the one path that couldn't opt in, because the macro never forwarded the key).

## Fix (two halves)

1. **`snapshot.sql` forwards `merge_materialize_source: true`** — hardcoded, like `on_schema_change`, not a passthrough: the snapshot source is inherently nondeterministic and dbt's own default snapshot materializes its staging as a real table for the same reason. The source is staged once into a local temp table; the guard, schema checks and delta-rs collection all read that one materialization.
2. **Empty-source short-circuit in `merge_delta_clauses`** (new `source_materialized` kwarg, threaded from `_store_merge` as `src_tmp is not None`): when the materialized source stages zero rows and no `not_matched_by_source` clause exists, skip the merge machinery outright — target open + `load_as_version` pin, delta-rs source collection/join build, the merge gate, and post-merge maintenance. delta-rs already declined to *commit* an empty merge, but only after paying all of that. The probe is one `LIMIT 1` off a local temp table and is never applied to a lazy source (it could re-run the model, and a nondeterministic model could answer "empty" for rows the merger would then see). Placed after the decoupled schema evolution, so `append_new_columns` still lands a new column carried by a zero-row source (`TestSnapshotSchemaEvolutionNoVersionChange` stays green).

The short-circuit also benefits any incremental merge that sets `merge_materialize_source: true` (or has `not_null` contract columns) and stages an empty increment.

## Not addressed here

Issue #61's item 5 (the ~53 `DeltaTable` opens during project-wide relation discovery) is a separate seam and is deliberately out of scope. Note #63 (checkpoint every 10 commits) bounds the log-replay cost of each open for tables created after it ships, which trims that same overhead from the other side.

## Tests

- `tests/adapter/test_review_fixes.py`: static pin that `snapshot.sql`'s merge dict forwards `'merge_materialize_source': true` (same class of regression the `_delta_core.sql` whitelist test pins); engine-level tests for the short-circuit — empty materialized source commits nothing, empty **lazy** source still runs the full merge (never probed), empty source under `WHEN NOT MATCHED BY SOURCE` still deletes, non-empty materialized source upserts byte-identically.
- `tests/conformance/test_simple_snapshot.py::TestUnchangedSnapshotCommitsNothing`: through real `dbt snapshot` — a re-run with an unchanged source leaves the Delta version untouched and the SCD2 content intact.

Local runs: `test_review_fixes.py` 62 passed; new + adjacent snapshot conformance classes passed; `snapshot_pin` suite 11 passed; `dbt_unit_tests -k materialize` passed. (The 4 pre-existing `TestSimpleSnapshotDuckDB` same-process failures reproduce identically on clean `main` on this Windows box and are unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
