### PR TITLE
ci: harden commit-docs action with env-var indirection

### DIFF
--- a/.github/actions/commit-docs/action.yml
+++ b/.github/actions/commit-docs/action.yml
@@ -25,20 +25,26 @@ runs:
   steps:
     - name: Commit to main (retrying past concurrent card commits)
       shell: bash
+      env:                      # env-var indirection: values reach bash as data, never as script text
+        CHECKOUT_MAIN: ${{ inputs.checkout-main }}
+        PREPARE: ${{ inputs.prepare }}
+        PATHS: ${{ inputs.paths }}
+        MESSAGE: ${{ inputs.message }}
       run: |
-        if [ "${{ inputs.checkout-main }}" = "true" ]; then
+        if [ "$CHECKOUT_MAIN" = "true" ]; then
           git fetch origin main
           git checkout -B main origin/main
         fi
-        ${{ inputs.prepare }}
-        if git diff --quiet -- ${{ inputs.paths }}; then
-          echo "Nothing changed under: ${{ inputs.paths }}"
+        eval "$PREPARE"
+        # $PATHS deliberately unquoted: the input is a space-separated path list
+        if git diff --quiet -- $PATHS; then
+          echo "Nothing changed under: $PATHS"
           exit 0
         fi
         git config user.name "djouallah"
         git config user.email "mimoune.djouallah@gmail.com"
-        git add ${{ inputs.paths }}
-        git commit -m "${{ inputs.message }}"
+        git add $PATHS
+        git commit -m "$MESSAGE"
         for i in 1 2 3; do
           git pull --rebase origin main && git push origin main && break
           sleep 3


### PR DESCRIPTION
Hardens `.github/actions/commit-docs/action.yml` against shell template injection, prompted by the scanner report in issue #65 (CWE-78: `${{ inputs.* }}` spliced directly into the `run:` block).

**Not exploitable today** — the action is a local composite action and all 8 call sites pass hardcoded literals from trusted contexts (push to main / workflow_call / workflow_dispatch; no `pull_request_target` in the repo). This is defense-in-depth: inputs now reach bash as env-var data, never as script text, so a future call site passing dynamic values can't inject commands.

Deliberate departures from the diff suggested in the issue:
- `$PATHS` stays **unquoted** in `git diff --` / `git add`: the input is a documented space-separated path list (cores.yml passes two paths); quoting it would collapse the list into one pathspec and silently break the conformance-card commit. Env-var expansion word-splits but is never re-parsed as shell syntax, so no injection either way.
- `eval "$PREPARE"` instead of `bash -c`: `prepare` is arbitrary repo-authored bash by contract; `eval` keeps the current same-shell semantics.

Verified locally: YAML parses, `bash -n` on the extracted run block, and the unquoted two-path `git diff --quiet` no-op check behaves as before. The real exercise is the next push to main that refreshes a card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)