### PR TITLE
test(bench): DuckDB-writer arm + a layout-only writer A/B CI

### DIFF
--- a/.github/workflows/parquet_layout.yml
+++ b/.github/workflows/parquet_layout.yml
@@ -84,6 +84,10 @@ on:
         description: "[aemo] duckdb_native only: DICTIONARY_SIZE_LIMIT — max distinct values per column that still dictionary-encodes. Empty = 16000000."
         type: string
         default: ""
+      opt_page_bytes:
+        description: "[aemo] duckdb_native only: DATA_PAGE_SIZE_LIMIT in bytes (duckdb#24645). Empty = 1048576 (~1 MB, the measured sweet spot of the page-size U-curve)."
+        type: string
+        default: ""
       dax:
         description: "run the Direct Lake half — deploy the two semantic models, walk the DAX suite, read the VertiPaq DMVs. OFF = layout only (sort key, table stats, parquet geometry): no semantic model is created, so it costs no interactive CU and finishes in minutes. Turn it off when the question is 'what did the picker choose / what shape did it write', on when the question is 'is it faster'."
         type: boolean
@@ -143,6 +147,14 @@ jobs:
         run: |
           pip install pythonnet pyyaml
           pip install -e .
+
+      - name: 🦆 Pin duckdb to the nightly that has DATA_PAGE_SIZE_LIMIT (duckdb#24645)
+        # Stable duckdb (<= 1.5.5) still hard-splits data pages at 100MB uncompressed — the exact
+        # failure that killed this arm's first run (duckdb#24507). Its own step so the delta_rs
+        # path stays byte-identical to main; build_duckdb_native.py probes the option at startup
+        # and dies loudly if this pin ever stops carrying it.
+        if: ${{ inputs.writer == 'duckdb_native' }}
+        run: pip install duckdb==1.6.0.dev365
 
       - name: 🧾 Init run report
         env:
@@ -230,6 +242,7 @@ jobs:
           OPT_SORT: ${{ inputs.opt_sort == 'auto' && 'date, time' || inputs.opt_sort }}
           OPT_RG: ${{ inputs.opt_rg }}
           OPT_DICT_LIMIT: ${{ inputs.opt_dict_limit }}
+          OPT_PAGE_BYTES: ${{ inputs.opt_page_bytes }}
           FORCE_REBUILD: ${{ inputs.rebuild }}
           BENCH_ROW_LIMIT: ${{ inputs.row_limit }}
         run: python tests/parquet_layout/aemo/build_duckdb_native.py

--- a/.github/workflows/parquet_layout.yml
+++ b/.github/workflows/parquet_layout.yml
@@ -243,6 +243,7 @@ jobs:
           OPT_RG: ${{ inputs.opt_rg }}
           OPT_DICT_LIMIT: ${{ inputs.opt_dict_limit }}
           OPT_PAGE_BYTES: ${{ inputs.opt_page_bytes }}
+          OPT_TFS_MB: ${{ inputs.opt_tfs_mb }}
           FORCE_REBUILD: ${{ inputs.rebuild }}
           BENCH_ROW_LIMIT: ${{ inputs.row_limit }}
         run: python tests/parquet_layout/aemo/build_duckdb_native.py

--- a/.github/workflows/parquet_layout.yml
+++ b/.github/workflows/parquet_layout.yml
@@ -73,6 +73,17 @@ on:
         description: "[aemo] pin the data-page ROW cap for the auto_sort build. Empty = the 1M default (raised from 20k in d0d23b4, so the 1 MB byte cap is what shapes pages). Use with rebuild=true."
         type: string
         default: ""
+      writer:
+        description: "[aemo] which writer builds the auto_sort table: delta_rs (CTAS, build_auto_sort.py) or duckdb_native (DuckDB COPY + delta-rs commit-only — exact 1-RG-per-file geometry, dictionary encoding control). Switch with rebuild=true or the existing table is reused."
+        type: choice
+        default: delta_rs
+        options:
+          - delta_rs
+          - duckdb_native
+      opt_dict_limit:
+        description: "[aemo] duckdb_native only: DICTIONARY_SIZE_LIMIT — max distinct values per column that still dictionary-encodes. Empty = 16000000."
+        type: string
+        default: ""
       dax:
         description: "run the Direct Lake half — deploy the two semantic models, walk the DAX suite, read the VertiPaq DMVs. OFF = layout only (sort key, table stats, parquet geometry): no semantic model is created, so it costs no interactive CU and finishes in minutes. Turn it off when the question is 'what did the picker choose / what shape did it write', on when the question is 'is it faster'."
         type: boolean
@@ -142,6 +153,7 @@ jobs:
           BENCH_ROW_LIMIT: ${{ inputs.row_limit }}
           BENCH_GAP_SECONDS: ${{ inputs.gap_seconds }}
           OPT_SORT: ${{ inputs.opt_sort }}
+          BENCH_WRITER: ${{ inputs.writer }}
           FORCE_REBUILD: ${{ inputs.rebuild }}
         run: |
           echo "RUN_REPORT=$PWD/run_report.json" >> "$GITHUB_ENV"
@@ -197,7 +209,7 @@ jobs:
         run: python tests/parquet_layout/aemo/build_spark_variant.py
 
       - name: 🧭 Build auto_sort summary table (duckrun sorted, reads mart.fct_summary directly)
-        if: ${{ inputs.rebuild || steps.check.outputs.build_needed == 'true' }}
+        if: ${{ inputs.writer != 'duckdb_native' && (inputs.rebuild || steps.check.outputs.build_needed == 'true') }}
         env:
           PYTHONIOENCODING: utf-8
           OPT_SORT: ${{ inputs.opt_sort }}
@@ -207,6 +219,20 @@ jobs:
           FORCE_REBUILD: ${{ inputs.rebuild }}
           BENCH_ROW_LIMIT: ${{ inputs.row_limit }}
         run: python tests/parquet_layout/aemo/build_auto_sort.py
+
+      - name: 🦆 Build auto_sort summary table (DuckDB COPY writes, delta-rs commits)
+        # Same table slot (tests.fct_summary_auto_sort) so deploy/stats/XMLA/DMV run unchanged.
+        # 'auto' is the delta-rs builder's sort spelling; the native builder needs explicit
+        # columns, so the input's default remaps to the measured best key.
+        if: ${{ inputs.writer == 'duckdb_native' && (inputs.rebuild || steps.check.outputs.build_needed == 'true') }}
+        env:
+          PYTHONIOENCODING: utf-8
+          OPT_SORT: ${{ inputs.opt_sort == 'auto' && 'date, time' || inputs.opt_sort }}
+          OPT_RG: ${{ inputs.opt_rg }}
+          OPT_DICT_LIMIT: ${{ inputs.opt_dict_limit }}
+          FORCE_REBUILD: ${{ inputs.rebuild }}
+          BENCH_ROW_LIMIT: ${{ inputs.row_limit }}
+        run: python tests/parquet_layout/aemo/build_duckdb_native.py
 
       - name: 🚀 Deploy benchmark semantic models (auto_sort + vorder)
         if: ${{ inputs.dax }}

--- a/.github/workflows/writer_ab.yml
+++ b/.github/workflows/writer_ab.yml
@@ -1,0 +1,122 @@
+name: Writer A/B (parquet layout)
+
+# MANUAL ONLY, non-gating. delta-rs vs DuckDB's own parquet writer, everything else held equal:
+# same source, same fixed sort key, same geometry knobs, same runner, same duckdb build. Two
+# coexisting tables in the aemo benchmark lakehouse, then a layout readout.
+#
+# Deliberately NOT this workflow's business: DAX, semantic models, XMLA, VertiPaq, V-Order. Those
+# live in parquet_layout.yml and cost interactive CU; this one answers "what parquet does each
+# writer emit" and nothing else, so it is cheap enough to run on every writer change.
+#
+#   tests.fct_summary_ab_deltars  <- build_auto_sort.py       (duckrun CTAS, delta-rs writes)
+#   tests.fct_summary_ab_duckdb   <- build_duckdb_native.py   (DuckDB COPY, delta-rs commits only)
+#
+# Both builders take their target from OPT_TABLE, so parquet_layout.yml's own shared slot
+# (tests.fct_summary_auto_sort) is untouched by anything here.
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: "deploy_config.yml env whose workspace/lakehouse to build in"
+        type: string
+        default: main
+      opt_sort:
+        description: "the FIXED sort key both writers use, e.g. 'date, time'. Explicit columns only — 'auto' would let the picker choose per writer, which is no longer an A/B."
+        type: string
+        default: "date, time"
+      row_limit:
+        description: "row cap on the shared source mart.fct_summary (142M ≈ full)"
+        type: string
+        default: "142000000"
+      opt_rg:
+        description: "row-group ceiling (rows) for BOTH writers. Empty = duckrun's fixed 6M."
+        type: string
+        default: ""
+      opt_tfs_mb:
+        description: "target parquet file size (MB) for BOTH writers. Empty = duckrun's 256 MB."
+        type: string
+        default: ""
+      opt_page_bytes:
+        description: "[duckdb arm] DATA_PAGE_SIZE_LIMIT in bytes (duckdb#24645). Empty = 1048576, matching the ~1 MB pages the delta-rs arm writes."
+        type: string
+        default: ""
+      rebuild:
+        description: "rebuild both tables even if they already exist (else each builder skips)"
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  writer_ab:
+    name: 🆚 delta-rs vs DuckDB writer
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      # duckrun mints every token it needs from this federated identity — no azure/login anywhere.
+      # NOTE a non-main branch needs its own federated credential on the app, or the mint fails
+      # with an unhelpful error (subject repo:djouallah/duckrun:ref:refs/heads/<branch>).
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🐍 Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: 📦 Install deps (duckrun from THIS tree)
+        run: |
+          pip install pyyaml
+          pip install -e .
+
+      - name: 🦆 Pin duckdb to the nightly that has DATA_PAGE_SIZE_LIMIT (duckdb#24645)
+        # Pinned for the WHOLE job, not just the duckdb arm: delta-rs writes its parquet through
+        # arrow-rs either way, so this cannot touch its output — and it means both arms read the
+        # source with the identical engine, which is the point of an A/B.
+        run: pip install duckdb==1.6.0.dev365
+
+      - name: 🔑 Resolve lakehouse + workspace (duckrun, no az)
+        run: python tests/parquet_layout/aemo/resolve_env.py --env ${{ inputs.env }}
+
+      - name: 🧭 Build the delta-rs table (duckrun CTAS)
+        env:
+          PYTHONIOENCODING: utf-8
+          OPT_TABLE: fct_summary_ab_deltars
+          OPT_SORT: ${{ inputs.opt_sort }}
+          OPT_RG: ${{ inputs.opt_rg }}
+          OPT_TFS_MB: ${{ inputs.opt_tfs_mb }}
+          FORCE_REBUILD: ${{ inputs.rebuild }}
+          BENCH_ROW_LIMIT: ${{ inputs.row_limit }}
+        run: python tests/parquet_layout/aemo/build_auto_sort.py
+
+      - name: 🦆 Build the DuckDB-writer table (COPY writes, delta-rs commits)
+        env:
+          PYTHONIOENCODING: utf-8
+          OPT_TABLE: fct_summary_ab_duckdb
+          OPT_SORT: ${{ inputs.opt_sort }}
+          OPT_RG: ${{ inputs.opt_rg }}
+          OPT_TFS_MB: ${{ inputs.opt_tfs_mb }}
+          OPT_PAGE_BYTES: ${{ inputs.opt_page_bytes }}
+          FORCE_REBUILD: ${{ inputs.rebuild }}
+          BENCH_ROW_LIMIT: ${{ inputs.row_limit }}
+        run: python tests/parquet_layout/aemo/build_duckdb_native.py
+
+      - name: 📊 Compare the two layouts
+        if: always()   # a failed build should still show whatever did land
+        env:
+          PYTHONIOENCODING: utf-8
+          OPT_SORT: ${{ inputs.opt_sort }}
+        run: python tests/parquet_layout/aemo/compare_writers.py
+
+      - name: 📎 Upload run report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: writer-ab-report
+          path: run_report.json
+          if-no-files-found: warn

--- a/tests/parquet_layout/aemo/build_auto_sort.py
+++ b/tests/parquet_layout/aemo/build_auto_sort.py
@@ -8,6 +8,11 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import report  # noqa: E402
 import sort_key as sort_key_mod  # noqa: E402
 
+# OPT_TABLE lets a caller aim this builder at its own slot (writer_ab.yml builds delta-rs and the
+# DuckDB writer side by side); the default keeps parquet_layout.yml's behaviour unchanged.
+TABLE = os.environ.get("OPT_TABLE") or "fct_summary_auto_sort"
+QUALIFIED = f"tests.{TABLE}"
+
 sort = sort_key_mod.requested()
 clause = "sorted by auto" if sort.lower() == "auto" else f"sorted by ({sort})"
 force = os.environ.get("FORCE_REBUILD", "false").strip().lower() == "true"
@@ -60,7 +65,7 @@ except Exception:
 
 def _exists():
     try:
-        con.sql("select 1 from tests.fct_summary_auto_sort limit 1").fetchone()
+        con.sql(f"select 1 from {QUALIFIED} limit 1").fetchone()
         return True
     except Exception:
         return False
@@ -69,23 +74,23 @@ def _exists():
 _t0 = time.perf_counter()
 sort_key = None
 if not force and _exists():
-    rows = con.sql("select count(*) from tests.fct_summary_auto_sort").fetchone()[0]
-    print(f"tests.fct_summary_auto_sort already exists ({rows:,} rows) — skipping "
+    rows = con.sql(f"select count(*) from {QUALIFIED}").fetchone()[0]
+    print(f"{QUALIFIED} already exists ({rows:,} rows) — skipping "
           "(rebuild=true to rebuild)", flush=True)
     status = "skipped"   # nothing was written, so no key was chosen — report null, not a guess
 else:
     body = f"select * from {_src}"
     sort_key = sort_key_mod.resolve(con, sort, body)
     print(f"sort key: {clause} -> {sort_key_mod.label(sort_key)}", flush=True)
-    print(f"Building tests.fct_summary_auto_sort with '{clause}' ...", flush=True)
+    print(f"Building {QUALIFIED} with '{clause}' ...", flush=True)
     # Read mart.fct_summary directly (independent of the Spark V-Order build's read); SORTED BY AUTO
     # re-sorts regardless of the source's order.
-    con.sql(f"create or replace table tests.fct_summary_auto_sort {clause} as {body}")
-    rows = con.sql("select count(*) from tests.fct_summary_auto_sort").fetchone()[0]
-    print(f"done — tests.fct_summary_auto_sort built ({rows:,} rows)", flush=True)
+    con.sql(f"create or replace table {QUALIFIED} {clause} as {body}")
+    rows = con.sql(f"select count(*) from {QUALIFIED}").fetchone()[0]
+    print(f"done — {QUALIFIED} built ({rows:,} rows)", flush=True)
     status = "rebuilt"
 
-report.merge({"tables": {"fct_summary_auto_sort": {"build": {
+report.merge({"tables": {TABLE: {"build": {
     "engine": "delta_rs", "sort": clause, "sort_key": sort_key, "vorder": False,
     "row_group_ceiling": OPT_RG,     # None = the fixed 6M default
     "target_file_size_mb": OPT_TFS_MB,  # None = the 256 MB default

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -11,15 +11,13 @@ globally sorted, dictionary-encoded everywhere (Direct Lake's cheap transcode is
 ID remap; anything plain gets re-encoded).
 
 Shape mechanics, each measured in a local probe before this was written:
-  * ONE sorted single-stream COPY — no temp table, no manual slicing (the sort spills instead of
-    materializing the whole fact). Files rotate on FILE_SIZE_BYTES (~256MB, duckrun's shipping
-    target) ALONG the sorted stream, so adjacent files stay disjoint on the sort key. The earlier
-    PER_THREAD_OUTPUT + ROW_GROUPS_PER_FILE 1 variant was measured and REJECTED: writer threads
-    carve the stream arbitrarily, giving 19/23 overlapping adjacent file pairs and ~70 MB of
-    excess (835 vs 765 MB vs V-Order, nearly all uncompressed `mw` bytes). One RG per file buys
-    nothing, and ROW_GROUPS_PER_FILE is only exact under PER_THREAD_OUTPUT anyway.
-    The explicit ORDER BY pins the written order on its own — no preserve_insertion_order
-    override (duckrun's session global stays false).
+  * ONE sorted SINGLE-THREADED COPY — no temp table, no manual slicing (the sort spills instead
+    of materializing the whole fact). Files rotate on FILE_SIZE_BYTES (~256MB, duckrun's shipping
+    target) along the sorted stream, so adjacent files stay disjoint on the sort key. threads=1
+    is mandatory for that: a multi-threaded COPY writes several files at once and their key
+    ranges interleave no matter how the sink is configured (see the SET threads=1 comment for
+    the measurements). The PER_THREAD_OUTPUT + ROW_GROUPS_PER_FILE 1 variant was measured and
+    REJECTED — one RG per file buys nothing and ROW_GROUPS_PER_FILE is only exact under it.
   * AddAction stats come from the parquet footers CAST to each column's DuckDB type, then
     re-serialized in Delta JSON spelling — the raw footer stat strings used as-is poisoned
     delta_scan's pruning to zero rows.
@@ -132,16 +130,20 @@ else:
     order = ", ".join(f'"{c}"' for c in sort_cols)
     run_tag = uuid.uuid4().hex[:8]
 
-    # ONE ordered output stream: no PER_THREAD_OUTPUT, so files rotate on FILE_SIZE_BYTES along
-    # the sorted stream instead of being split per writer thread. The per-thread variant measured
-    # 19/23 adjacent file pairs OVERLAPPING on the sort key (run 32462888170) — threads carve the
-    # stream arbitrarily, which destroys file-level clustering and cost ~70 MB (835 vs 765 MB vs
-    # V-Order, almost all of it uncompressed `mw` bytes). ROW_GROUPS_PER_FILE is dropped with it:
-    # it is only exact under PER_THREAD_OUTPUT, and one-RG-per-file buys nothing here.
-    # threads=2 stays as the OOM guard (1.6.0.dev365 died at 4 threads on the 12.4GiB runner at
-    # both 16M and 6M row groups). The explicit ORDER BY pins the written order — no
-    # preserve_insertion_order override (duckrun's global false stays).
-    dd.execute("SET threads=2")
+    # threads=1 is the whole ballgame for cross-file clustering, and it is NOT about
+    # PER_THREAD_OUTPUT or preserve_insertion_order. ANY multi-threaded parquet COPY writes
+    # several files concurrently, so writer threads consume the sorted stream in parallel and
+    # their key ranges interleave. Measured locally (10M rows, rotation exercised):
+    #   threads=1 -> 7 files, overlap 0/6 (clean disjoint slices), 17.9s
+    #   threads=2 -> 7 files, overlap 6/6,                          9.2s
+    #   threads=4 -> 7 files, overlap 6/6
+    # preserve_insertion_order true vs false made NO difference to any of it — the ORDER BY
+    # governs, so duckrun's global false stays untouched. On the real fact the parallel variants
+    # measured 19/23 (PER_THREAD_OUTPUT, 24 files) and 2/2 (single stream, 3 files) overlapping
+    # pairs, costing ~70 MB vs V-Order (835 vs 765 MB, nearly all uncompressed `mw` bytes —
+    # dictionary indices that lost their runs). One writer also buffers one row group, so this
+    # is what fixes the 12.4GiB-runner OOM as well. ~2x slower; the layout is the point.
+    dd.execute("SET threads=1")
     print(f"{n_src:,} rows -> one sorted single-stream COPY, "
           f"ROW_GROUP_SIZE {RG:,} x FILE_SIZE_BYTES {FILE_BYTES:,} "
           f"x DATA_PAGE_SIZE_LIMIT {PAGE_BYTES:,}", flush=True)

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -16,7 +16,8 @@ Shape mechanics, each measured in a local probe before this was written:
     docs, per_thread_output makes ROW_GROUPS_PER_FILE accurate ("only one thread writes to
     each file"); without it a probe wrote an 8-row-group file. The cost is sort-key range
     overlap ACROSS files (threads split the sorted stream) — accepted; per-file clustering
-    holds. preserve_insertion_order=true because duckrun's session global is false.
+    holds. The explicit ORDER BY pins the written order on its own — no
+    preserve_insertion_order override (duckrun's session global stays false).
   * AddAction stats come from the parquet footers CAST to each column's DuckDB type, then
     re-serialized in Delta JSON spelling — the raw footer stat strings used as-is poisoned
     delta_scan's pruning to zero rows.
@@ -130,9 +131,11 @@ else:
     # PER_THREAD_OUTPUT makes ROW_GROUPS_PER_FILE exact ("only one thread writes to each file,
     # and it becomes accurate again" — DuckDB COPY docs; probed: N files x exactly 1 RG). The
     # trade-off is cross-file range overlap on the sort key (threads split the sorted stream);
-    # per-file clustering is kept and the overlap is accepted. preserve_insertion_order=true
-    # because duckrun's session global is false; throwaway session, no restore.
-    dd.execute("SET preserve_insertion_order=true")
+    # per-file clustering is kept and the overlap is accepted. No preserve_insertion_order
+    # override: the explicit ORDER BY pins the written order by itself (duckrun's global false
+    # stays), and threads=2 because 1.6.0.dev365's scan+sort OOM'd the 12.4GiB runner at 4
+    # threads regardless of row-group size (16M and 6M both died ~30s in; fit on 1.5.5).
+    dd.execute("SET threads=2")
     print(f"{n_src:,} rows -> one sorted parallel COPY, "
           f"PER_THREAD_OUTPUT x ROW_GROUPS_PER_FILE 1 x ROW_GROUP_SIZE {RG:,} "
           f"x DATA_PAGE_SIZE_LIMIT {PAGE_BYTES:,}", flush=True)

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -1,0 +1,229 @@
+"""Build tests.fct_summary_auto_sort with DUCKDB'S OWN PARQUET WRITER; delta-rs only COMMITS.
+
+Same table slot as build_auto_sort.py, so deploy_vorder / table_stats / xmla_compare /
+vertipaq_dmv all run unchanged — the `writer` workflow input picks which builder fills it.
+
+Why this exists: delta-rs's writer cannot produce N files of exactly one clean row group (its
+byte cap truncates the in-flight group at the roll — measured on 1.5.0), and it exposes no
+per-column encoding control. DuckDB COPY has both levers. Target layout = spark V-Order's
+physical shape minus the V-Order encoding itself: K files x ONE full row group of ~OPT_RG rows,
+globally sorted, dictionary-encoded everywhere (Direct Lake's cheap transcode is the dictionary
+ID remap; anything plain gets re-encoded).
+
+Shape mechanics, each measured in a local probe before this was written:
+  * ONE sorted streaming COPY with PER_THREAD_OUTPUT + ROW_GROUPS_PER_FILE 1 — no temp table,
+    no manual slicing (the sort spills instead of materializing the whole fact). Per the COPY
+    docs, per_thread_output makes ROW_GROUPS_PER_FILE accurate ("only one thread writes to
+    each file"); without it a probe wrote an 8-row-group file. The cost is sort-key range
+    overlap ACROSS files (threads split the sorted stream) — accepted; per-file clustering
+    holds. preserve_insertion_order=true because duckrun's session global is false.
+  * AddAction stats come from the parquet footers CAST to each column's DuckDB type, then
+    re-serialized in Delta JSON spelling — the raw footer stat strings used as-is poisoned
+    delta_scan's pruning to zero rows.
+  * DICTIONARY_SIZE_LIMIT is raised so no column falls out of dictionary at 16M-row groups —
+    DuckDB's default is ROW_GROUP_SIZE/5, and 1.5.5 dictionary-encodes every type at any NDV
+    under the limit. (Exception: DECIMAL(p>18) writes FLBA, never dictionary — the mart already
+    stores decimal(18,4), and the post-commit WARN names any column that slips out.)
+
+Env: ONELAKE_TABLES_PATH (resolve_env), OPT_SORT (explicit columns, default 'date, time' —
+'auto' is the delta-rs builder's spelling and is rejected here), OPT_RG (rows/group+file,
+default 16000000), OPT_DICT_LIMIT (default 16000000), BENCH_ROW_LIMIT, FORCE_REBUILD.
+"""
+import datetime as _dt
+import decimal as _dec
+import json
+import os
+import sys
+import time
+import uuid
+
+import duckrun
+from deltalake import DeltaTable, Schema
+from deltalake.transaction import AddAction, create_table_with_add_actions
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import report  # noqa: E402
+
+TABLE = "fct_summary_auto_sort"
+
+RG = int(os.environ.get("OPT_RG") or 16_000_000)
+DICT_LIMIT = int(os.environ.get("OPT_DICT_LIMIT") or 16_000_000)
+sort = (os.environ.get("OPT_SORT") or "date, time").strip()
+if sort.lower() == "auto":
+    raise SystemExit("build_duckdb_native: OPT_SORT must be explicit columns (e.g. 'date, time'); "
+                     "'auto' belongs to the delta-rs builder (build_auto_sort.py).")
+sort_cols = [c.strip() for c in sort.split(",") if c.strip()]
+force = os.environ.get("FORCE_REBUILD", "false").strip().lower() == "true"
+_lim = os.environ.get("BENCH_ROW_LIMIT", "").strip()
+N_CAP = int(_lim) if _lim.isdigit() and int(_lim) > 0 else None
+
+tables_root = os.environ["ONELAKE_TABLES_PATH"].rstrip("/")
+table_uri = f"{tables_root}/tests/{TABLE}"
+
+con = duckrun.connect(tables_root, read_only=False)
+dd = con.con
+try:
+    con.sql("create schema if not exists tests")
+except Exception:
+    dd.execute("create schema if not exists tests")
+
+
+def _exists():
+    try:
+        con.sql(f"select 1 from tests.{TABLE} limit 1").fetchone()
+        return True
+    except Exception:
+        return False
+
+
+def _delta_json(v):
+    if isinstance(v, _dt.datetime):
+        return v.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    if isinstance(v, (_dt.date, _dt.time)):
+        return str(v)
+    if isinstance(v, _dec.Decimal):  # Delta JSON stats spell decimals as numbers
+        return float(v)
+    return v
+
+
+_t0 = time.perf_counter()
+if not force and _exists():
+    rows = con.sql(f"select count(*) from tests.{TABLE}").fetchone()[0]
+    print(f"tests.{TABLE} already exists ({rows:,} rows) — skipping (rebuild=true to rebuild)",
+          flush=True)
+    status, k, n = "skipped", None, rows
+else:
+    src = "mart.fct_summary" if N_CAP is None else f"(select * from mart.fct_summary limit {N_CAP})"
+    n_src = dd.execute(f"select count(*) from {src}").fetchone()[0]
+
+    # column types drive the typed stats casts below; the mart already stores decimal(18,4)
+    # (duckrun's write path narrows wide decimals), so everything here dictionary-encodes —
+    # a DECIMAL(p>18) source would write FLBA, which never gets a dictionary (the WARN catches it)
+    coltypes = dict(dd.execute(f"select column_name, column_type from (describe {src})").fetchall())
+    cols = list(coltypes)
+    collist = ", ".join(f'"{c}"' for c in cols)
+    order = ", ".join(f'"{c}"' for c in sort_cols)
+    run_tag = uuid.uuid4().hex[:8]
+
+    # PER_THREAD_OUTPUT makes ROW_GROUPS_PER_FILE exact ("only one thread writes to each file,
+    # and it becomes accurate again" — DuckDB COPY docs; probed: N files x exactly 1 RG). The
+    # trade-off is cross-file range overlap on the sort key (threads split the sorted stream);
+    # per-file clustering is kept and the overlap is accepted. preserve_insertion_order=true
+    # because duckrun's session global is false; throwaway session, no restore.
+    dd.execute("SET preserve_insertion_order=true")
+    print(f"{n_src:,} rows -> one sorted parallel COPY, "
+          f"PER_THREAD_OUTPUT x ROW_GROUPS_PER_FILE 1 x ROW_GROUP_SIZE {RG:,}", flush=True)
+    t_s = time.perf_counter()
+    dd.execute(f"""
+        COPY (select {collist} from {src} order by {order})
+        TO '{table_uri}'
+        (FORMAT parquet, ROW_GROUP_SIZE {RG}, ROW_GROUPS_PER_FILE 1,
+         DICTIONARY_SIZE_LIMIT {DICT_LIMIT}, COMPRESSION snappy,
+         PER_THREAD_OUTPUT, FILENAME_PATTERN 'part-{run_tag}-{{uuid}}', APPEND)
+    """)
+    print(f"copied in {time.perf_counter() - t_s:.1f}s", flush=True)
+
+    # Sizes from a real listing (the AddAction size field should be true, not guessed).
+    from dbt.adapters.duckrun.objectstore import build_store
+    import obstore
+    store = build_store(table_uri, con.storage_options)
+    sizes = {}
+    for batch in obstore.list(store):
+        for obj in batch:
+            p = obj["path"]
+            if p.rsplit("/", 1)[-1].startswith(f"part-{run_tag}-"):
+                sizes[p.rsplit("/", 1)[-1]] = obj["size"]
+    if not sizes:
+        raise SystemExit(f"listing returned no part-{run_tag}-* files")
+    files = sorted(sizes)
+    k = len(files)
+
+    # Explicit file list, no glob: globbing abfss:// needs a LIST the azure extension can't
+    # parse against OneLake (json.exception.type_error.302); direct GETs work fine.
+    flist = "[" + ", ".join(f"'{table_uri}/{f}'" for f in files) + "]"
+
+    nrows = {f.rsplit("/", 1)[-1]: r for f, r in dd.execute(
+        f"select file_name, num_rows from parquet_file_metadata({flist})").fetchall()}
+    n = sum(nrows.values())
+    if n != n_src:
+        raise SystemExit(f"row count mismatch after COPY: files {n:,} vs source {n_src:,}")
+
+    # Typed per-file stats from the footers: CAST each stat string to the column's type, then
+    # spell it Delta-JSON. cast (not try_cast): an unparseable stat should kill the build loudly.
+    mins: dict = {f: {} for f in files}
+    maxs: dict = {f: {} for f in files}
+    nulls: dict = {f: {} for f in files}
+    for c in cols:
+        t = coltypes[c]
+        for f, mn, mx, nc in dd.execute(f"""
+            select file_name, cast(stats_min_value as {t}), cast(stats_max_value as {t}),
+                   coalesce(stats_null_count, 0)
+            from parquet_metadata({flist}) where path_in_schema = '{c}'
+        """).fetchall():
+            b = f.rsplit("/", 1)[-1]
+            mins[b][c], maxs[b][c], nulls[b][c] = mn, mx, int(nc)
+
+    now_ms = int(time.time() * 1000)
+    actions = []
+    for f in files:
+        stats = json.dumps({
+            "numRecords": nrows[f],
+            "minValues": {c: _delta_json(mins[f][c]) for c in cols},
+            "maxValues": {c: _delta_json(maxs[f][c]) for c in cols},
+            "nullCount": {c: nulls[f][c] for c in cols},
+        })
+        actions.append(AddAction(path=f, size=sizes[f], partition_values={},
+                                 modification_time=now_ms, data_change=True, stats=stats))
+
+    # arro3 (a deltalake dep) reads the relation's Arrow C-stream — CI has no pyarrow (test-only dep)
+    from arro3.core import RecordBatchReader
+    schema = Schema.from_arrow(
+        RecordBatchReader.from_stream(dd.sql(f"select {collist} from {src} limit 0")).schema)
+
+    so = con.storage_options
+    try:
+        dt = DeltaTable(table_uri, storage_options=so)
+        # existing table (either builder's output): overwrite emits the removes for the old files
+        dt.create_write_transaction(actions, mode="overwrite", schema=schema)
+    except Exception as ex:
+        if "not a delta table" not in str(ex).lower() and type(ex).__name__ != "TableNotFoundError":
+            raise
+        create_table_with_add_actions(table_uri, schema, actions, mode="error",
+                                      storage_options=so)
+    print(f"committed {k} add action(s) -> v{DeltaTable(table_uri, storage_options=so).version()}",
+          flush=True)
+
+    # ---- verify the layout on the REAL files: a silently wrong shape would corrupt the A/B.
+    meta = dd.execute(f"""
+        select file_name, count(distinct row_group_id),
+               min(case when path_in_schema = '{sort_cols[0]}' then stats_min_value end),
+               max(case when path_in_schema = '{sort_cols[0]}' then stats_max_value end)
+        from parquet_metadata({flist})
+        group by 1 order by 3
+    """).fetchall()
+    multi = [m[0] for m in meta if m[1] != 1]
+    if multi:
+        raise SystemExit(f"layout verification FAILED: multi-RG files={multi}")
+    rng = [(m[2], m[3]) for m in meta]
+    overlaps = sum(1 for a, b in zip(rng, rng[1:]) if b[0] < a[1])
+    # informational: PER_THREAD_OUTPUT trades cross-file ordering for parallel writes
+    print(f"{sort_cols[0]} range overlap across files: {overlaps}/{max(len(rng) - 1, 1)} "
+          f"adjacent pairs", flush=True)
+    non_dict = dd.execute(f"""
+        select distinct path_in_schema, encodings
+        from parquet_metadata({flist})
+        where not (contains(encodings, 'RLE_DICTIONARY') or contains(encodings, 'PLAIN_DICTIONARY'))
+    """).fetchall()
+    if non_dict:  # warn only: a data property (e.g. >DICT_LIMIT distinct doubles), not a bug
+        print(f"WARN: columns not fully dictionary-encoded: {non_dict}", flush=True)
+    n_back = dd.execute(f"select count(*) from delta_scan('{table_uri}')").fetchone()[0]
+    if n_back != n_src:
+        raise SystemExit(f"row count mismatch after commit: delta_scan {n_back:,} vs source {n_src:,}")
+    print(f"verified: {len(meta)} file(s) x 1 RG, {n_back:,} rows readable", flush=True)
+    status = "rebuilt"
+
+report.merge({"tables": {TABLE: {"build": {
+    "engine": "duckdb_copy+delta_commit", "sort": f"sorted by ({sort})", "vorder": False,
+    "row_group_ceiling": RG, "dictionary_size_limit": DICT_LIMIT,
+    "files": k, "rows": n,
+    "seconds": round(time.perf_counter() - _t0, 1), "status": status}}}})

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -11,13 +11,15 @@ globally sorted, dictionary-encoded everywhere (Direct Lake's cheap transcode is
 ID remap; anything plain gets re-encoded).
 
 Shape mechanics, each measured in a local probe before this was written:
-  * ONE sorted streaming COPY with PER_THREAD_OUTPUT + ROW_GROUPS_PER_FILE 1 — no temp table,
-    no manual slicing (the sort spills instead of materializing the whole fact). Per the COPY
-    docs, per_thread_output makes ROW_GROUPS_PER_FILE accurate ("only one thread writes to
-    each file"); without it a probe wrote an 8-row-group file. The cost is sort-key range
-    overlap ACROSS files (threads split the sorted stream) — accepted; per-file clustering
-    holds. The explicit ORDER BY pins the written order on its own — no
-    preserve_insertion_order override (duckrun's session global stays false).
+  * ONE sorted single-stream COPY — no temp table, no manual slicing (the sort spills instead of
+    materializing the whole fact). Files rotate on FILE_SIZE_BYTES (~256MB, duckrun's shipping
+    target) ALONG the sorted stream, so adjacent files stay disjoint on the sort key. The earlier
+    PER_THREAD_OUTPUT + ROW_GROUPS_PER_FILE 1 variant was measured and REJECTED: writer threads
+    carve the stream arbitrarily, giving 19/23 overlapping adjacent file pairs and ~70 MB of
+    excess (835 vs 765 MB vs V-Order, nearly all uncompressed `mw` bytes). One RG per file buys
+    nothing, and ROW_GROUPS_PER_FILE is only exact under PER_THREAD_OUTPUT anyway.
+    The explicit ORDER BY pins the written order on its own — no preserve_insertion_order
+    override (duckrun's session global stays false).
   * AddAction stats come from the parquet footers CAST to each column's DuckDB type, then
     re-serialized in Delta JSON spelling — the raw footer stat strings used as-is poisoned
     delta_scan's pruning to zero rows.
@@ -33,10 +35,11 @@ Shape mechanics, each measured in a local probe before this was written:
     option — a stable build would silently write the broken layout and corrupt the A/B.
 
 Env: ONELAKE_TABLES_PATH (resolve_env), OPT_SORT (explicit columns, default 'date, time' —
-'auto' is the delta-rs builder's spelling and is rejected here), OPT_RG (rows/group+file,
-default 6000000 = duckrun's fixed write geometry; 4 threads each buffering a full 16M-row
-group OOM'd the 12.4GiB runner on 1.6.0.dev365), OPT_DICT_LIMIT (default 16000000),
-OPT_PAGE_BYTES (default 1048576), BENCH_ROW_LIMIT, FORCE_REBUILD.
+'auto' is the delta-rs builder's spelling and is rejected here), OPT_RG (rows per row group,
+default 6000000 = duckrun's fixed write geometry; the nightly OOM'd the 12.4GiB runner at 4
+threads), OPT_DICT_LIMIT (default 16000000), OPT_PAGE_BYTES (default 1048576),
+OPT_TFS_MB (file rotation size, default 256 = duckrun's target_file_size_mb),
+BENCH_ROW_LIMIT, FORCE_REBUILD.
 """
 import datetime as _dt
 import decimal as _dec
@@ -60,6 +63,7 @@ TABLE = "fct_summary_auto_sort"
 RG = int(os.environ.get("OPT_RG") or 6_000_000)
 DICT_LIMIT = int(os.environ.get("OPT_DICT_LIMIT") or 16_000_000)
 PAGE_BYTES = int(os.environ.get("OPT_PAGE_BYTES") or 1_048_576)
+FILE_BYTES = int(float(os.environ.get("OPT_TFS_MB") or 256) * 1024 * 1024)
 sort = (os.environ.get("OPT_SORT") or "date, time").strip()
 if sort.lower() == "auto":
     raise SystemExit("build_duckdb_native: OPT_SORT must be explicit columns (e.g. 'date, time'); "
@@ -128,25 +132,27 @@ else:
     order = ", ".join(f'"{c}"' for c in sort_cols)
     run_tag = uuid.uuid4().hex[:8]
 
-    # PER_THREAD_OUTPUT makes ROW_GROUPS_PER_FILE exact ("only one thread writes to each file,
-    # and it becomes accurate again" — DuckDB COPY docs; probed: N files x exactly 1 RG). The
-    # trade-off is cross-file range overlap on the sort key (threads split the sorted stream);
-    # per-file clustering is kept and the overlap is accepted. No preserve_insertion_order
-    # override: the explicit ORDER BY pins the written order by itself (duckrun's global false
-    # stays), and threads=2 because 1.6.0.dev365's scan+sort OOM'd the 12.4GiB runner at 4
-    # threads regardless of row-group size (16M and 6M both died ~30s in; fit on 1.5.5).
+    # ONE ordered output stream: no PER_THREAD_OUTPUT, so files rotate on FILE_SIZE_BYTES along
+    # the sorted stream instead of being split per writer thread. The per-thread variant measured
+    # 19/23 adjacent file pairs OVERLAPPING on the sort key (run 32462888170) — threads carve the
+    # stream arbitrarily, which destroys file-level clustering and cost ~70 MB (835 vs 765 MB vs
+    # V-Order, almost all of it uncompressed `mw` bytes). ROW_GROUPS_PER_FILE is dropped with it:
+    # it is only exact under PER_THREAD_OUTPUT, and one-RG-per-file buys nothing here.
+    # threads=2 stays as the OOM guard (1.6.0.dev365 died at 4 threads on the 12.4GiB runner at
+    # both 16M and 6M row groups). The explicit ORDER BY pins the written order — no
+    # preserve_insertion_order override (duckrun's global false stays).
     dd.execute("SET threads=2")
-    print(f"{n_src:,} rows -> one sorted parallel COPY, "
-          f"PER_THREAD_OUTPUT x ROW_GROUPS_PER_FILE 1 x ROW_GROUP_SIZE {RG:,} "
+    print(f"{n_src:,} rows -> one sorted single-stream COPY, "
+          f"ROW_GROUP_SIZE {RG:,} x FILE_SIZE_BYTES {FILE_BYTES:,} "
           f"x DATA_PAGE_SIZE_LIMIT {PAGE_BYTES:,}", flush=True)
     t_s = time.perf_counter()
     dd.execute(f"""
         COPY (select {collist} from {src} order by {order})
         TO '{table_uri}'
-        (FORMAT parquet, ROW_GROUP_SIZE {RG}, ROW_GROUPS_PER_FILE 1,
+        (FORMAT parquet, ROW_GROUP_SIZE {RG}, FILE_SIZE_BYTES {FILE_BYTES},
          DICTIONARY_SIZE_LIMIT {DICT_LIMIT}, DATA_PAGE_SIZE_LIMIT {PAGE_BYTES},
          COMPRESSION snappy,
-         PER_THREAD_OUTPUT, FILENAME_PATTERN 'part-{run_tag}-{{uuid}}', APPEND)
+         FILENAME_PATTERN 'part-{run_tag}-{{uuid}}', APPEND)
     """)
     print(f"copied in {time.perf_counter() - t_s:.1f}s", flush=True)
 
@@ -228,12 +234,11 @@ else:
         from parquet_metadata({flist})
         group by 1 order by 3
     """).fetchall()
-    multi = [m[0] for m in meta if m[1] != 1]
-    if multi:
-        raise SystemExit(f"layout verification FAILED: multi-RG files={multi}")
+    rgs = sum(m[1] for m in meta)
     rng = [(m[2], m[3]) for m in meta]
     overlaps = sum(1 for a, b in zip(rng, rng[1:]) if b[0] < a[1])
-    # informational: PER_THREAD_OUTPUT trades cross-file ordering for parallel writes
+    # THE metric for the single-stream shape: files rotate along the sorted stream, so adjacent
+    # files should NOT overlap on the sort key. The PER_THREAD_OUTPUT variant scored 19/23.
     print(f"{sort_cols[0]} range overlap across files: {overlaps}/{max(len(rng) - 1, 1)} "
           f"adjacent pairs", flush=True)
     non_dict = dd.execute(f"""
@@ -246,12 +251,13 @@ else:
     n_back = dd.execute(f"select count(*) from delta_scan('{table_uri}')").fetchone()[0]
     if n_back != n_src:
         raise SystemExit(f"row count mismatch after commit: delta_scan {n_back:,} vs source {n_src:,}")
-    print(f"verified: {len(meta)} file(s) x 1 RG, {n_back:,} rows readable", flush=True)
+    print(f"verified: {len(meta)} file(s) / {rgs} row group(s), {n_back:,} rows readable",
+          flush=True)
     status = "rebuilt"
 
 report.merge({"tables": {TABLE: {"build": {
     "engine": "duckdb_copy+delta_commit", "sort": f"sorted by ({sort})", "vorder": False,
     "row_group_ceiling": RG, "dictionary_size_limit": DICT_LIMIT,
-    "data_page_size_limit": PAGE_BYTES,
+    "data_page_size_limit": PAGE_BYTES, "file_size_bytes": FILE_BYTES,
     "files": k, "rows": n,
     "seconds": round(time.perf_counter() - _t0, 1), "status": status}}}})

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -24,19 +24,28 @@ Shape mechanics, each measured in a local probe before this was written:
     DuckDB's default is ROW_GROUP_SIZE/5, and 1.5.5 dictionary-encodes every type at any NDV
     under the limit. (Exception: DECIMAL(p>18) writes FLBA, never dictionary — the mart already
     stores decimal(18,4), and the post-commit WARN names any column that slips out.)
+  * DATA_PAGE_SIZE_LIMIT caps data pages at ~1MB uncompressed (duckdb#24645, nightly-only until
+    the next stable). This arm's first run died on the old hardcoded 100MB split: ONE giant page
+    per 16M-row column chunk, which the consumer transcodes 5-26x slower (duckdb#24507). ~1MB is
+    the measured sweet spot of the page-size U-curve, and matches what the delta-rs builder has
+    written since d0d23b4. A startup probe fails the build loudly on any duckdb without the
+    option — a stable build would silently write the broken layout and corrupt the A/B.
 
 Env: ONELAKE_TABLES_PATH (resolve_env), OPT_SORT (explicit columns, default 'date, time' —
 'auto' is the delta-rs builder's spelling and is rejected here), OPT_RG (rows/group+file,
-default 16000000), OPT_DICT_LIMIT (default 16000000), BENCH_ROW_LIMIT, FORCE_REBUILD.
+default 16000000), OPT_DICT_LIMIT (default 16000000), OPT_PAGE_BYTES (default 1048576),
+BENCH_ROW_LIMIT, FORCE_REBUILD.
 """
 import datetime as _dt
 import decimal as _dec
 import json
 import os
 import sys
+import tempfile
 import time
 import uuid
 
+import duckdb
 import duckrun
 from deltalake import DeltaTable, Schema
 from deltalake.transaction import AddAction, create_table_with_add_actions
@@ -48,6 +57,7 @@ TABLE = "fct_summary_auto_sort"
 
 RG = int(os.environ.get("OPT_RG") or 16_000_000)
 DICT_LIMIT = int(os.environ.get("OPT_DICT_LIMIT") or 16_000_000)
+PAGE_BYTES = int(os.environ.get("OPT_PAGE_BYTES") or 1_048_576)
 sort = (os.environ.get("OPT_SORT") or "date, time").strip()
 if sort.lower() == "auto":
     raise SystemExit("build_duckdb_native: OPT_SORT must be explicit columns (e.g. 'date, time'); "
@@ -62,6 +72,17 @@ table_uri = f"{tables_root}/tests/{TABLE}"
 
 con = duckrun.connect(tables_root, read_only=False)
 dd = con.con
+
+# Probe DATA_PAGE_SIZE_LIMIT before any expensive work: a duckdb without it (any stable <= 1.5.5)
+# would silently write the old broken layout — one ~100MB page per column chunk — and corrupt the A/B.
+_probe = os.path.join(tempfile.mkdtemp(prefix="duckrun_page_probe_"), "probe.parquet").replace("\\", "/")
+try:
+    dd.execute(f"COPY (select 1 as x) TO '{_probe}' (FORMAT parquet, DATA_PAGE_SIZE_LIMIT {PAGE_BYTES})")
+except Exception as ex:
+    raise SystemExit(
+        f"build_duckdb_native: this duckdb ({duckdb.__version__}) rejected DATA_PAGE_SIZE_LIMIT "
+        f"(duckdb#24645, nightlies only until the next stable; the workflow pins "
+        f"duckdb==1.6.0.dev365 for writer=duckdb_native): {ex}")
 try:
     con.sql("create schema if not exists tests")
 except Exception:
@@ -112,13 +133,15 @@ else:
     # because duckrun's session global is false; throwaway session, no restore.
     dd.execute("SET preserve_insertion_order=true")
     print(f"{n_src:,} rows -> one sorted parallel COPY, "
-          f"PER_THREAD_OUTPUT x ROW_GROUPS_PER_FILE 1 x ROW_GROUP_SIZE {RG:,}", flush=True)
+          f"PER_THREAD_OUTPUT x ROW_GROUPS_PER_FILE 1 x ROW_GROUP_SIZE {RG:,} "
+          f"x DATA_PAGE_SIZE_LIMIT {PAGE_BYTES:,}", flush=True)
     t_s = time.perf_counter()
     dd.execute(f"""
         COPY (select {collist} from {src} order by {order})
         TO '{table_uri}'
         (FORMAT parquet, ROW_GROUP_SIZE {RG}, ROW_GROUPS_PER_FILE 1,
-         DICTIONARY_SIZE_LIMIT {DICT_LIMIT}, COMPRESSION snappy,
+         DICTIONARY_SIZE_LIMIT {DICT_LIMIT}, DATA_PAGE_SIZE_LIMIT {PAGE_BYTES},
+         COMPRESSION snappy,
          PER_THREAD_OUTPUT, FILENAME_PATTERN 'part-{run_tag}-{{uuid}}', APPEND)
     """)
     print(f"copied in {time.perf_counter() - t_s:.1f}s", flush=True)
@@ -225,5 +248,6 @@ else:
 report.merge({"tables": {TABLE: {"build": {
     "engine": "duckdb_copy+delta_commit", "sort": f"sorted by ({sort})", "vorder": False,
     "row_group_ceiling": RG, "dictionary_size_limit": DICT_LIMIT,
+    "data_page_size_limit": PAGE_BYTES,
     "files": k, "rows": n,
     "seconds": round(time.perf_counter() - _t0, 1), "status": status}}}})

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -56,7 +56,9 @@ from deltalake.transaction import AddAction, create_table_with_add_actions
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import report  # noqa: E402
 
-TABLE = "fct_summary_auto_sort"
+# OPT_TABLE lets a caller aim this builder at its own slot (writer_ab.yml builds both writers
+# side by side); the default keeps parquet_layout.yml's shared-slot behaviour unchanged.
+TABLE = os.environ.get("OPT_TABLE") or "fct_summary_auto_sort"
 
 RG = int(os.environ.get("OPT_RG") or 6_000_000)
 DICT_LIMIT = int(os.environ.get("OPT_DICT_LIMIT") or 16_000_000)

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -20,7 +20,7 @@ Shape mechanics, each measured in a local probe before this was written:
   * AddAction stats come from the parquet footers CAST to each column's DuckDB type, then
     re-serialized in Delta JSON spelling — the raw footer stat strings used as-is poisoned
     delta_scan's pruning to zero rows.
-  * DICTIONARY_SIZE_LIMIT is raised so no column falls out of dictionary at 16M-row groups —
+  * DICTIONARY_SIZE_LIMIT is raised so no column falls out of dictionary even at 16M-row groups —
     DuckDB's default is ROW_GROUP_SIZE/5, and 1.5.5 dictionary-encodes every type at any NDV
     under the limit. (Exception: DECIMAL(p>18) writes FLBA, never dictionary — the mart already
     stores decimal(18,4), and the post-commit WARN names any column that slips out.)
@@ -33,8 +33,9 @@ Shape mechanics, each measured in a local probe before this was written:
 
 Env: ONELAKE_TABLES_PATH (resolve_env), OPT_SORT (explicit columns, default 'date, time' —
 'auto' is the delta-rs builder's spelling and is rejected here), OPT_RG (rows/group+file,
-default 16000000), OPT_DICT_LIMIT (default 16000000), OPT_PAGE_BYTES (default 1048576),
-BENCH_ROW_LIMIT, FORCE_REBUILD.
+default 6000000 = duckrun's fixed write geometry; 4 threads each buffering a full 16M-row
+group OOM'd the 12.4GiB runner on 1.6.0.dev365), OPT_DICT_LIMIT (default 16000000),
+OPT_PAGE_BYTES (default 1048576), BENCH_ROW_LIMIT, FORCE_REBUILD.
 """
 import datetime as _dt
 import decimal as _dec
@@ -55,7 +56,7 @@ import report  # noqa: E402
 
 TABLE = "fct_summary_auto_sort"
 
-RG = int(os.environ.get("OPT_RG") or 16_000_000)
+RG = int(os.environ.get("OPT_RG") or 6_000_000)
 DICT_LIMIT = int(os.environ.get("OPT_DICT_LIMIT") or 16_000_000)
 PAGE_BYTES = int(os.environ.get("OPT_PAGE_BYTES") or 1_048_576)
 sort = (os.environ.get("OPT_SORT") or "date, time").strip()

--- a/tests/parquet_layout/aemo/compare_writers.py
+++ b/tests/parquet_layout/aemo/compare_writers.py
@@ -1,0 +1,119 @@
+"""Side-by-side parquet layout of the two writers, everything else held equal.
+
+Reads the pair `writer_ab.yml` just built — `tests.fct_summary_ab_deltars` (delta-rs CTAS) and
+`tests.fct_summary_ab_duckdb` (DuckDB COPY + delta-rs commit-only) — and prints what the layout
+actually looks like: table geometry, per-column bytes and encodings, and how well each writer kept
+the sort key clustered across files.
+
+No DAX, no semantic model, no V-Order: the question here is purely "given the same source, the same
+sort key and the same geometry knobs, what parquet does each writer emit?".
+
+Env: ONELAKE_TABLES_PATH (resolve_env), AB_PREFIX (table-name prefix, default 'fct_summary_ab'),
+OPT_SORT (to know which column clustering is measured on; default 'date, time'), RUN_REPORT.
+"""
+import os
+import sys
+
+import duckrun
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import report  # noqa: E402
+
+PREFIX = os.environ.get("AB_PREFIX") or "fct_summary_ab"
+SORT_COL = ((os.environ.get("OPT_SORT") or "date, time").split(",")[0]).strip()
+
+con = duckrun.connect(os.environ["ONELAKE_TABLES_PATH"], schema="tests")
+
+stats = con.get_stats(f"{PREFIX}_*").fetchall()          # catalog, schema, table, rows, files, ...
+if not stats:
+    raise SystemExit(f"compare_writers: no tables matched tests.{PREFIX}_* — did the builds run?")
+tables = sorted(r[2] for r in stats)
+
+# build seconds / engine come from whatever the two builders merged into the run report
+_rep = {}
+_path = os.environ.get("RUN_REPORT", "run_report.json")
+if os.path.exists(_path):
+    import json
+    with open(_path, encoding="utf-8") as f:
+        _rep = json.load(f).get("tables", {})
+
+
+def _build(t, field, default=None):
+    return (_rep.get(t) or {}).get("build", {}).get(field, default)
+
+
+# ---- per-column bytes + encodings, and the per-file sort-key ranges, in one detailed pass
+detail = con.get_stats(f"{PREFIX}_*", detailed=True)
+cols = detail.aggregate("""
+    "table", path_in_schema, any_value(type) as type,
+    round(sum(total_compressed_size)/1048576.0, 1) as comp_mb,
+    round(sum(total_uncompressed_size)/1048576.0, 1) as uncomp_mb,
+    string_agg(distinct encodings, ' | ') as encodings
+""").fetchall()
+
+# Clustering: adjacent files must not overlap on the sort key. Footer stats come back as strings,
+# so cast to the live column type — lexicographic order is not numeric order.
+coltype = dict(con.con.execute(
+    f'select column_name, column_type from (describe select * from tests.{tables[0]})').fetchall()
+)[SORT_COL]
+ranges = detail.filter(f"path_in_schema = '{SORT_COL}'").aggregate(f"""
+    "table", file_name,
+    min(cast(stats_min_value as {coltype})) as mn,
+    max(cast(stats_max_value as {coltype})) as mx
+""").order('"table", mn').fetchall()
+
+overlap = {}
+for t in tables:
+    r = [(a, b) for tbl, _f, a, b in ranges if tbl == t]
+    overlap[t] = (sum(1 for x, y in zip(r, r[1:]) if y[0] < x[1]), max(len(r) - 1, 1))
+
+out = [f"## Writer A/B — parquet layout ({', '.join(tables)})", ""]
+out.append("| metric | " + " | ".join(tables) + " |")
+out.append("|---|" + "---|" * len(tables))
+
+
+def _row(label, fn):
+    out.append(f"| {label} | " + " | ".join(str(fn(t)) for t in tables) + " |")
+
+
+by_table = {r[2]: r for r in stats}
+_row("writer", lambda t: _build(t, "engine", "?"))
+_row("sort", lambda t: _build(t, "sort", "?"))
+_row("build seconds", lambda t: _build(t, "seconds", "?"))
+_row("rows", lambda t: f"{by_table[t][3]:,}")
+_row("size (MB)", lambda t: by_table[t][7])
+_row("files", lambda t: by_table[t][4])
+_row("row groups", lambda t: by_table[t][5])
+_row("avg row group", lambda t: f"{by_table[t][6]:,.0f}")
+_row("compression", lambda t: by_table[t][9])   # 8 is vorder, 9 is compression
+_row(f"{SORT_COL} overlap across files", lambda t: f"{overlap[t][0]}/{overlap[t][1]}")
+
+out += ["", f"### Per column (sorted by size in {tables[0]})", ""]
+out.append("| column | type | " + " | ".join(f"{t} comp / uncomp MB" for t in tables)
+           + " | encodings |")
+out.append("|---|---|" + "---|" * len(tables) + "---|")
+names = [c[1] for c in cols if c[0] == tables[0]]
+names.sort(key=lambda n: -next(c[3] for c in cols if c[0] == tables[0] and c[1] == n))
+for n in names:
+    cells, encs = [], []
+    for t in tables:
+        c = next((c for c in cols if c[0] == t and c[1] == n), None)
+        cells.append(f"{c[3]} / {c[4]}" if c else "—")
+        if c:
+            encs.append(f"{t.rsplit('_', 1)[-1]}: {c[5]}")
+    typ = next(c[2] for c in cols if c[0] == tables[0] and c[1] == n)
+    out.append(f"| {n} | {typ} | " + " | ".join(cells) + " | " + "<br>".join(encs) + " |")
+
+text = "\n".join(out)
+print("\n" + text, flush=True)
+summary = os.environ.get("GITHUB_STEP_SUMMARY")
+if summary:
+    with open(summary, "a", encoding="utf-8") as f:
+        f.write(text + "\n\n")
+
+report.merge({"writer_ab": {t: {
+    "size_mb": by_table[t][7], "files": by_table[t][4], "row_groups": by_table[t][5],
+    "avg_row_group": by_table[t][6], "engine": _build(t, "engine"),
+    "seconds": _build(t, "seconds"),
+    "sort_key_overlap": f"{overlap[t][0]}/{overlap[t][1]}",
+} for t in tables}})

--- a/tests/parquet_layout/aemo/report.py
+++ b/tests/parquet_layout/aemo/report.py
@@ -57,6 +57,7 @@ def _init():
             "row_limit": _int("BENCH_ROW_LIMIT"),
             "gap_seconds": _int("BENCH_GAP_SECONDS"),
             "opt_sort": os.environ.get("OPT_SORT"),
+            "writer": os.environ.get("BENCH_WRITER"),
             "rebuild": _bool("FORCE_REBUILD"),
         },
         "duckrun_version": dv,


### PR DESCRIPTION
Resurrects the DuckDB-writer benchmark arm (DuckDB `COPY` writes the parquet, delta-rs commits only)
and adds a standalone CI to compare it against delta-rs on parquet layout.

**Why now.** The arm was concluded in August because DuckDB's parquet writer split data pages only at
a hardcoded 100 MB, producing one giant page per column chunk. duckdb/duckdb#24645 (merged Aug 10)
adds the `DATA_PAGE_SIZE_LIMIT` COPY option that fixes it, so the experiment is worth re-running.

**What landed while getting it green** (each measured, not guessed):
- `threads=1` is mandatory for cross-file clustering. Any multi-threaded parquet COPY writes several
  files concurrently, so writer threads carve the sorted stream in parallel and their key ranges
  interleave. Local 10M-row probe: 1 thread → 0/6 overlapping file pairs, 2 → 6/6, 4 → 6/6. It also
  fixes an OOM on the runner, since one writer buffers one row group.
- `preserve_insertion_order` is irrelevant here — true vs false gave identical results; the `ORDER BY`
  governs. duckrun's global `false` is untouched.
- `PER_THREAD_OUTPUT` + `ROW_GROUPS_PER_FILE 1` dropped: one row group per file buys nothing, and that
  option is what scattered the sort key (19 of 23 adjacent file pairs overlapped).

**New workflow — `writer_ab.yml`.** Manual, non-gating, layout only: no DAX, no semantic models, no
XMLA, no V-Order, so it costs no interactive CU. It builds `tests.fct_summary_ab_deltars` and
`tests.fct_summary_ab_duckdb` from the same source with the same fixed sort key, the same geometry
and the same pinned duckdb, then reports geometry, per-column bytes/encodings and sort-key overlap.

It needs to be on the default branch because GitHub only dispatches `workflow_dispatch` workflows
that exist there.

**Blast radius.** Test harness only — no `duckrun/` or `dbt/` changes, no new engine knobs. Both
builders now take their target table from `OPT_TABLE` defaulting to the current name, so
`parquet_layout.yml` is behaviourally unchanged; its `writer` input defaults to `delta_rs`, and the
pinned duckdb nightly installs only when that input selects the DuckDB arm.
