### PR TITLE
test(bench): cold-only Direct Lake + CU benchmark

### DIFF
--- a/.github/workflows/writer_ab.yml
+++ b/.github/workflows/writer_ab.yml
@@ -47,6 +47,10 @@ on:
         options:
           - V1
           - V2
+      opt_bloom:
+        description: "[duckdb arm] write parquet bloom filters. DuckDB does by default and delta-rs never does; they sit between row groups and are invisible to a per-column footer sum (~32 MB on the real fact). Default false so the A/B compares writers, not features."
+        type: boolean
+        default: false
       opt_dict_limit:
         description: "[duckdb arm] DICTIONARY_SIZE_LIMIT — max distinct values per column that still dictionary-encodes. Empty = 16000000, i.e. NEVER fall out of dictionary. Set to 0 to use DuckDB's own default (ROW_GROUP_SIZE/5), which lets high-cardinality columns fall back like delta-rs does."
         type: string
@@ -115,6 +119,7 @@ jobs:
           OPT_PAGE_BYTES: ${{ inputs.opt_page_bytes }}
           OPT_PARQUET_VERSION: ${{ inputs.opt_parquet_version }}
           OPT_DICT_LIMIT: ${{ inputs.opt_dict_limit }}
+          OPT_BLOOM: ${{ inputs.opt_bloom }}
           FORCE_REBUILD: ${{ inputs.rebuild }}
           BENCH_ROW_LIMIT: ${{ inputs.row_limit }}
         run: python tests/parquet_layout/aemo/build_duckdb_native.py

--- a/.github/workflows/writer_ab.yml
+++ b/.github/workflows/writer_ab.yml
@@ -52,7 +52,7 @@ on:
         type: boolean
         default: false
       opt_dict_limit:
-        description: "[duckdb arm] DICTIONARY_SIZE_LIMIT — max distinct values per column that still dictionary-encodes. Empty = 16000000, i.e. NEVER fall out of dictionary. Set to 0 to use DuckDB's own default (ROW_GROUP_SIZE/5), which lets high-cardinality columns fall back like delta-rs does."
+        description: "[duckdb arm] DIAGNOSTIC ONLY — leave empty. DICTIONARY_SIZE_LIMIT, max distinct values per column that still dictionary-encodes. Empty = 16000000, i.e. never fall out of dictionary, which is what we want: the consuming engine remaps dictionary IDs cheaply and would have to re-encode plain values. Lowering it trades that away for ~36 MB."
         type: string
         default: ""
       rebuild:

--- a/.github/workflows/writer_ab.yml
+++ b/.github/workflows/writer_ab.yml
@@ -40,6 +40,17 @@ on:
         description: "[duckdb arm] DATA_PAGE_SIZE_LIMIT in bytes (duckdb#24645). Empty = 1048576, matching the ~1 MB pages the delta-rs arm writes."
         type: string
         default: ""
+      opt_parquet_version:
+        description: "[duckdb arm] PARQUET_VERSION. V1 writes PLAIN_DICTIONARY, V2 writes RLE_DICTIONARY — the same physical encoding under two spec names, measured byte-identical locally."
+        type: choice
+        default: V1
+        options:
+          - V1
+          - V2
+      opt_dict_limit:
+        description: "[duckdb arm] DICTIONARY_SIZE_LIMIT — max distinct values per column that still dictionary-encodes. Empty = 16000000, i.e. NEVER fall out of dictionary. Set to 0 to use DuckDB's own default (ROW_GROUP_SIZE/5), which lets high-cardinality columns fall back like delta-rs does."
+        type: string
+        default: ""
       rebuild:
         description: "rebuild both tables even if they already exist (else each builder skips)"
         type: boolean
@@ -102,6 +113,8 @@ jobs:
           OPT_RG: ${{ inputs.opt_rg }}
           OPT_TFS_MB: ${{ inputs.opt_tfs_mb }}
           OPT_PAGE_BYTES: ${{ inputs.opt_page_bytes }}
+          OPT_PARQUET_VERSION: ${{ inputs.opt_parquet_version }}
+          OPT_DICT_LIMIT: ${{ inputs.opt_dict_limit }}
           FORCE_REBUILD: ${{ inputs.rebuild }}
           BENCH_ROW_LIMIT: ${{ inputs.row_limit }}
         run: python tests/parquet_layout/aemo/build_duckdb_native.py

--- a/.github/workflows/writer_cold.yml
+++ b/.github/workflows/writer_cold.yml
@@ -1,0 +1,198 @@
+name: Writer cold benchmark (Direct Lake + CU)
+
+# MANUAL ONLY, non-gating. Answers the one question the layout A/B cannot: is the DuckDB writer's
+# parquet actually good to READ COLD in Direct Lake, and what does it cost in capacity units.
+#
+# Cold-only by construction. There is no warm pass and no hot pass, and nothing is ever cleared:
+# a FRESH semantic model is the cold guarantee, because a new dataset is the only reliable way to
+# get an empty column store. Each query touches a column nothing has touched yet, so its duration
+# is that column's Delta->memory transcode. probe_rowcount runs last as the ~zero-column control.
+#
+# Every Fabric item here is created by the run and deleted at the end. That is the design, not
+# tidiness: fresh items mean fresh GUIDs, which is what makes the per-item CU read unambiguous.
+#
+#   wab_deltars.tests.fct_summary_deltars  <- build_auto_sort.py      (delta-rs writes)
+#   wab_duckdb.tests.fct_summary_duckdb    <- build_duckdb_native.py  (DuckDB COPY writes)
+#
+# THIS COSTS REAL CAPACITY. It writes ~1.6 GB, deploys two Direct Lake models and queries them.
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: "deploy_config.yml env whose workspace hosts the temp items (and the source mart)"
+        type: string
+        default: main
+      opt_sort:
+        description: "the FIXED sort key both writers use. Explicit columns only."
+        type: string
+        default: "date, time"
+      row_limit:
+        description: "row cap on the shared source mart.fct_summary (142M ≈ full)"
+        type: string
+        default: "142000000"
+      keep:
+        description: "skip teardown and leave the lakehouses + models standing (debugging). They bill storage until removed by hand."
+        type: boolean
+        default: false
+      settle_run:
+        description: "CU settle mode: re-read a past run's CU instead of benchmarking. Pass the ledger key (or 'all' for every unsettled run). Leave empty for a normal run."
+        type: string
+        default: ""
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  cold:
+    name: 🧊 Cold Direct Lake — delta-rs vs DuckDB
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      METRICS_WORKSPACE_ID: ${{ secrets.METRICS_WORKSPACE_ID }}
+      METRICS_MODEL_ID: ${{ secrets.METRICS_MODEL_ID }}
+      CAPACITY_ID: ${{ secrets.CAPACITY_ID }}
+      LH_DELTARS: wab_deltars
+      LH_DUCKDB: wab_duckdb
+      MODEL_DELTARS: writer_cold_deltars
+      MODEL_DUCKDB: writer_cold_duckdb
+      TABLE_DELTARS: fct_summary_deltars
+      TABLE_DUCKDB: fct_summary_duckdb
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🐍 Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: 📦 Install deps (duckrun from THIS tree)
+        run: |
+          pip install pythonnet pyyaml
+          pip install -e .
+
+      - name: 🦆 Pin duckdb to the nightly that has DATA_PAGE_SIZE_LIMIT (duckdb#24645)
+        run: pip install duckdb==1.6.0.dev365
+
+      - name: 🧩 Install ADOMD.NET client (.NET Core build, cross-platform)
+        run: |
+          set -euo pipefail
+          proj="$RUNNER_TEMP/adomd"
+          mkdir -p "$proj" && cd "$proj"
+          dotnet new console -o . --force >/dev/null
+          dotnet add package Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64 >/dev/null
+          dotnet publish -c Release -o publish >/dev/null
+          test -f "$proj/publish/Microsoft.AnalysisServices.AdomdClient.dll"
+          echo "ADOMD_DIR=$proj/publish" >> "$GITHUB_ENV"
+
+      - name: 🔑 Resolve workspace + source lakehouse
+        run: |
+          echo "RUN_REPORT=$PWD/run_report.json" >> "$GITHUB_ENV"
+          python tests/parquet_layout/aemo/resolve_env.py --env ${{ inputs.env }}
+
+      - name: 📌 Pin the SOURCE tables path under its own name
+        # resolve_env sets ONELAKE_TABLES_PATH to the PERMANENT lakehouse (where mart.fct_summary
+        # lives). The build steps override that variable to point at their temp lakehouse, so the
+        # source must be captured under a different name first — a step cannot safely reference a
+        # variable it is itself overriding.
+        run: echo "SRC_TABLES=$ONELAKE_TABLES_PATH" >> "$GITHUB_ENV"
+
+      # ---- CU settle mode: re-read a past run and exit. No items are created.
+      - name: 💰 Settle CU for a past run
+        if: ${{ inputs.settle_run != '' }}
+        run: |
+          if [ "${{ inputs.settle_run }}" = "all" ]; then
+            python tests/parquet_layout/writer_cold/cu.py settle
+          else
+            python tests/parquet_layout/writer_cold/cu.py settle --run "${{ inputs.settle_run }}"
+          fi
+
+      - name: 🏗️ Provision the throwaway lakehouses
+        if: ${{ inputs.settle_run == '' }}
+        run: |
+          echo "RUN_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+          python tests/parquet_layout/writer_cold/provision.py create
+
+      - name: 🧭 Build the delta-rs table
+        if: ${{ inputs.settle_run == '' }}
+        env:
+          PYTHONIOENCODING: utf-8
+          # write into the temp lakehouse, read the permanent mart
+          ONELAKE_TABLES_PATH: ${{ env.TABLES_DELTARS }}
+          BENCH_SOURCE: delta_scan('${{ env.SRC_TABLES }}/mart/fct_summary')
+          OPT_TABLE: ${{ env.TABLE_DELTARS }}
+          OPT_SORT: ${{ inputs.opt_sort }}
+          FORCE_REBUILD: "true"
+          BENCH_ROW_LIMIT: ${{ inputs.row_limit }}
+        run: python tests/parquet_layout/aemo/build_auto_sort.py
+
+      - name: 🦆 Build the DuckDB-writer table
+        if: ${{ inputs.settle_run == '' }}
+        env:
+          PYTHONIOENCODING: utf-8
+          ONELAKE_TABLES_PATH: ${{ env.TABLES_DUCKDB }}
+          BENCH_SOURCE: delta_scan('${{ env.SRC_TABLES }}/mart/fct_summary')
+          OPT_TABLE: ${{ env.TABLE_DUCKDB }}
+          OPT_SORT: ${{ inputs.opt_sort }}
+          FORCE_REBUILD: "true"
+          BENCH_ROW_LIMIT: ${{ inputs.row_limit }}
+        run: python tests/parquet_layout/aemo/build_duckdb_native.py
+
+      - name: 🚀 Deploy the two fresh Direct Lake models
+        if: ${{ inputs.settle_run == '' }}
+        env:
+          PYTHONIOENCODING: utf-8
+        run: python tests/parquet_layout/writer_cold/deploy_models.py
+
+      - name: 🧊 Cold pass — delta-rs
+        if: ${{ inputs.settle_run == '' }}
+        env:
+          PYTHONNET_RUNTIME: coreclr
+          PYTHONIOENCODING: utf-8
+          PYTHONUNBUFFERED: "1"
+          MODEL: ${{ env.MODEL_DELTARS }}
+          VARIANT: deltars
+        run: python tests/parquet_layout/writer_cold/cold_bench.py
+
+      - name: 🧊 Cold pass — DuckDB writer
+        if: ${{ inputs.settle_run == '' }}
+        env:
+          PYTHONNET_RUNTIME: coreclr
+          PYTHONIOENCODING: utf-8
+          PYTHONUNBUFFERED: "1"
+          MODEL: ${{ env.MODEL_DUCKDB }}
+          VARIANT: duckdb
+        run: python tests/parquet_layout/writer_cold/cold_bench.py
+
+      - name: 💰 Read CU (lower bound — it accrues for ~70 min)
+        if: ${{ inputs.settle_run == '' }}
+        continue-on-error: true   # a CU read must never lose us the cold numbers
+        env:
+          PYTHONNET_RUNTIME: coreclr
+          PYTHONIOENCODING: utf-8
+        run: |
+          python tests/parquet_layout/writer_cold/cu.py read \
+            --items "{\"deltars_model\":\"$MODEL_ID_DELTARS\",\"duckdb_model\":\"$MODEL_ID_DUCKDB\",\"deltars_lakehouse\":\"$LH_ID_DELTARS\",\"duckdb_lakehouse\":\"$LH_ID_DUCKDB\"}" \
+            --since-iso "$RUN_START" --label "${{ github.run_id }}"
+
+      - name: 📊 Summary
+        if: ${{ always() && inputs.settle_run == '' }}
+        continue-on-error: true
+        run: python tests/parquet_layout/writer_cold/render_cold.py
+
+      - name: 🧹 Teardown (always — a leaked lakehouse bills forever)
+        if: ${{ always() && inputs.settle_run == '' && !inputs.keep }}
+        run: python tests/parquet_layout/writer_cold/provision.py drop
+
+      - name: 📎 Upload run report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: writer-cold-report
+          path: |
+            run_report.json
+            tests/parquet_layout/writer_cold/cu_history.json
+          if-no-files-found: warn

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -11,13 +11,13 @@ globally sorted, dictionary-encoded everywhere (Direct Lake's cheap transcode is
 ID remap; anything plain gets re-encoded).
 
 Shape mechanics, each measured in a local probe before this was written:
-  * ONE sorted SINGLE-THREADED COPY — no temp table, no manual slicing (the sort spills instead
-    of materializing the whole fact). Files rotate on FILE_SIZE_BYTES (~256MB, duckrun's shipping
-    target) along the sorted stream, so adjacent files stay disjoint on the sort key. threads=1
-    is mandatory for that: a multi-threaded COPY writes several files at once and their key
-    ranges interleave no matter how the sink is configured (see the SET threads=1 comment for
-    the measurements). The PER_THREAD_OUTPUT + ROW_GROUPS_PER_FILE 1 variant was measured and
-    REJECTED — one RG per file buys nothing and ROW_GROUPS_PER_FILE is only exact under it.
+  * ONE sorted COPY — no temp table, no manual slicing (the sort spills instead of materializing
+    the whole fact), no thread pinning. Files rotate on FILE_SIZE_BYTES (~256MB, duckrun's
+    shipping target) along the sorted stream. Adjacent files WILL overlap on the sort key at
+    more than one thread, and that is accepted: the clustering it would buy was measured worth
+    0.05% of the table, and delta-rs ships overlapping files itself. PER_THREAD_OUTPUT +
+    ROW_GROUPS_PER_FILE 1 also measured and REJECTED — one RG per file buys nothing, and
+    ROW_GROUPS_PER_FILE is only exact under PER_THREAD_OUTPUT anyway.
   * AddAction stats come from the parquet footers CAST to each column's DuckDB type, then
     re-serialized in Delta JSON spelling — the raw footer stat strings used as-is poisoned
     delta_scan's pruning to zero rows.
@@ -37,7 +37,8 @@ Env: ONELAKE_TABLES_PATH (resolve_env), OPT_SORT (explicit columns, default 'dat
 default 6000000 = duckrun's fixed write geometry; the nightly OOM'd the 12.4GiB runner at 4
 threads), OPT_DICT_LIMIT (default 16000000), OPT_PAGE_BYTES (default 1048576),
 OPT_TFS_MB (file rotation size, default 256 = duckrun's target_file_size_mb),
-BENCH_ROW_LIMIT, FORCE_REBUILD.
+OPT_PARQUET_VERSION (V1/V2, byte-identical), OPT_BLOOM (default false — delta-rs writes none,
+and they cost 29.2 MB here), BENCH_ROW_LIMIT, FORCE_REBUILD.
 """
 import datetime as _dt
 import decimal as _dec
@@ -152,19 +153,16 @@ else:
     run_tag = uuid.uuid4().hex[:8]
 
     # threads=1 is the whole ballgame for cross-file clustering, and it is NOT about
-    # PER_THREAD_OUTPUT or preserve_insertion_order. ANY multi-threaded parquet COPY writes
-    # several files concurrently, so writer threads consume the sorted stream in parallel and
-    # their key ranges interleave. Measured locally (10M rows, rotation exercised):
-    #   threads=1 -> 7 files, overlap 0/6 (clean disjoint slices), 17.9s
-    #   threads=2 -> 7 files, overlap 6/6,                          9.2s
-    #   threads=4 -> 7 files, overlap 6/6
-    # preserve_insertion_order true vs false made NO difference to any of it — the ORDER BY
-    # governs, so duckrun's global false stays untouched. On the real fact the parallel variants
-    # measured 19/23 (PER_THREAD_OUTPUT, 24 files) and 2/2 (single stream, 3 files) overlapping
-    # pairs, costing ~70 MB vs V-Order (835 vs 765 MB, nearly all uncompressed `mw` bytes —
-    # dictionary indices that lost their runs). One writer also buffers one row group, so this
-    # is what fixes the 12.4GiB-runner OOM as well. ~2x slower; the layout is the point.
-    dd.execute("SET threads=1")
+    # No thread pinning: the writer runs at whatever duckrun's session set. Single-threaded
+    # writing buys DISJOINT files on the sort key (locally: 1 thread -> 0/6 overlapping pairs,
+    # 2 or 4 threads -> 6/6, because any multi-threaded parquet COPY writes several files at once
+    # and the writers carve the sorted stream in parallel) — but that clustering was measured to
+    # be worth ~nothing here: going from 19/23 to 0/2 overlapping pairs on the real fact moved
+    # the table 835.08 -> 834.66 MB, 0.05%. delta-rs, the writer this is compared against, ships
+    # 2/3 overlapping files itself. So the constraint is not worth paying for.
+    # NOTE if this OOMs the runner again, the fix is fewer threads: 1.6.0.dev365 died on a
+    # 12.4GiB runner at 4 threads at both 16M and 6M row groups (each writer buffers a full
+    # uncompressed row group), and 2 threads was fine.
     print(f"{n_src:,} rows -> one sorted single-stream COPY, "
           f"ROW_GROUP_SIZE {RG:,} x FILE_SIZE_BYTES {FILE_BYTES:,} "
           f"x DATA_PAGE_SIZE_LIMIT {PAGE_BYTES:,} x {PQ_VERSION} x DICTIONARY_SIZE_LIMIT "

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -61,9 +61,20 @@ import report  # noqa: E402
 TABLE = os.environ.get("OPT_TABLE") or "fct_summary_auto_sort"
 
 RG = int(os.environ.get("OPT_RG") or 6_000_000)
-DICT_LIMIT = int(os.environ.get("OPT_DICT_LIMIT") or 16_000_000)
+# 16M (>= any row group) means NO column ever falls out of dictionary. OPT_DICT_LIMIT=0 omits the
+# option so DuckDB applies its own default (ROW_GROUP_SIZE/5) and high-cardinality columns fall
+# back off dictionary — which is what delta-rs does (its footers carry PLAIN alongside
+# RLE_DICTIONARY) and is worth 2.3x locally on a high-cardinality probe.
+_dl = (os.environ.get("OPT_DICT_LIMIT") or "").strip()
+DICT_LIMIT = None if _dl == "0" else int(_dl or 16_000_000)
 PAGE_BYTES = int(os.environ.get("OPT_PAGE_BYTES") or 1_048_576)
 FILE_BYTES = int(float(os.environ.get("OPT_TFS_MB") or 256) * 1024 * 1024)
+# V1 writes PLAIN_DICTIONARY, V2 writes RLE_DICTIONARY — the SAME physical encoding under two
+# spec names (V1's is the deprecated alias), measured byte-identical locally at both low and high
+# cardinality. Knob exists so that claim is testable on the real fact, not to tune anything.
+PQ_VERSION = (os.environ.get("OPT_PARQUET_VERSION") or "V1").strip().upper()
+if PQ_VERSION not in ("V1", "V2"):
+    raise SystemExit(f"build_duckdb_native: OPT_PARQUET_VERSION must be V1 or V2, got {PQ_VERSION!r}")
 sort = (os.environ.get("OPT_SORT") or "date, time").strip()
 if sort.lower() == "auto":
     raise SystemExit("build_duckdb_native: OPT_SORT must be explicit columns (e.g. 'date, time'); "
@@ -148,14 +159,16 @@ else:
     dd.execute("SET threads=1")
     print(f"{n_src:,} rows -> one sorted single-stream COPY, "
           f"ROW_GROUP_SIZE {RG:,} x FILE_SIZE_BYTES {FILE_BYTES:,} "
-          f"x DATA_PAGE_SIZE_LIMIT {PAGE_BYTES:,}", flush=True)
+          f"x DATA_PAGE_SIZE_LIMIT {PAGE_BYTES:,} x {PQ_VERSION} x DICTIONARY_SIZE_LIMIT "
+          f"{f'{DICT_LIMIT:,}' if DICT_LIMIT else 'duckdb default'}", flush=True)
+    _dict_opt = f"DICTIONARY_SIZE_LIMIT {DICT_LIMIT}," if DICT_LIMIT else ""
     t_s = time.perf_counter()
     dd.execute(f"""
         COPY (select {collist} from {src} order by {order})
         TO '{table_uri}'
         (FORMAT parquet, ROW_GROUP_SIZE {RG}, FILE_SIZE_BYTES {FILE_BYTES},
-         DICTIONARY_SIZE_LIMIT {DICT_LIMIT}, DATA_PAGE_SIZE_LIMIT {PAGE_BYTES},
-         COMPRESSION snappy,
+         {_dict_opt} DATA_PAGE_SIZE_LIMIT {PAGE_BYTES},
+         COMPRESSION snappy, PARQUET_VERSION {PQ_VERSION},
          FILENAME_PATTERN 'part-{run_tag}-{{uuid}}', APPEND)
     """)
     print(f"copied in {time.perf_counter() - t_s:.1f}s", flush=True)
@@ -263,5 +276,6 @@ report.merge({"tables": {TABLE: {"build": {
     "engine": "duckdb_copy+delta_commit", "sort": f"sorted by ({sort})", "vorder": False,
     "row_group_ceiling": RG, "dictionary_size_limit": DICT_LIMIT,
     "data_page_size_limit": PAGE_BYTES, "file_size_bytes": FILE_BYTES,
+    "parquet_version": PQ_VERSION,
     "files": k, "rows": n,
     "seconds": round(time.perf_counter() - _t0, 1), "status": status}}}})

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -12,12 +12,12 @@ ID remap; anything plain gets re-encoded).
 
 Shape mechanics, each measured in a local probe before this was written:
   * ONE sorted COPY — no temp table, no manual slicing (the sort spills instead of materializing
-    the whole fact), no thread pinning. Files rotate on FILE_SIZE_BYTES (~256MB, duckrun's
-    shipping target) along the sorted stream. Adjacent files WILL overlap on the sort key at
-    more than one thread, and that is accepted: the clustering it would buy was measured worth
-    0.05% of the table, and delta-rs ships overlapping files itself. PER_THREAD_OUTPUT +
-    ROW_GROUPS_PER_FILE 1 also measured and REJECTED — one RG per file buys nothing, and
-    ROW_GROUPS_PER_FILE is only exact under PER_THREAD_OUTPUT anyway.
+    the whole fact). Files rotate on FILE_SIZE_BYTES (~256MB, duckrun's shipping target) along
+    the sorted stream. Runs at 2 threads, purely so the runner does not OOM (each writer buffers
+    a full uncompressed row group); adjacent files therefore DO overlap on the sort key, which is
+    accepted — that clustering was measured worth 0.05% of the table and delta-rs overlaps too.
+    PER_THREAD_OUTPUT + ROW_GROUPS_PER_FILE 1 also measured and REJECTED — one RG per file buys
+    nothing, and ROW_GROUPS_PER_FILE is only exact under PER_THREAD_OUTPUT anyway.
   * AddAction stats come from the parquet footers CAST to each column's DuckDB type, then
     re-serialized in Delta JSON spelling — the raw footer stat strings used as-is poisoned
     delta_scan's pruning to zero rows.
@@ -153,16 +153,17 @@ else:
     run_tag = uuid.uuid4().hex[:8]
 
     # threads=1 is the whole ballgame for cross-file clustering, and it is NOT about
-    # No thread pinning: the writer runs at whatever duckrun's session set. Single-threaded
-    # writing buys DISJOINT files on the sort key (locally: 1 thread -> 0/6 overlapping pairs,
-    # 2 or 4 threads -> 6/6, because any multi-threaded parquet COPY writes several files at once
-    # and the writers carve the sorted stream in parallel) — but that clustering was measured to
-    # be worth ~nothing here: going from 19/23 to 0/2 overlapping pairs on the real fact moved
-    # the table 835.08 -> 834.66 MB, 0.05%. delta-rs, the writer this is compared against, ships
-    # 2/3 overlapping files itself. So the constraint is not worth paying for.
-    # NOTE if this OOMs the runner again, the fix is fewer threads: 1.6.0.dev365 died on a
-    # 12.4GiB runner at 4 threads at both 16M and 6M row groups (each writer buffers a full
-    # uncompressed row group), and 2 threads was fine.
+    # threads=2 is a MEMORY guard, not a layout one. Each writer thread buffers a full
+    # uncompressed row group, so the runner's default 4 threads OOMs a 12.4GiB box on this fact —
+    # measured three times now: at 16M rows/group, at 6M, and again with no pin at all
+    # (run 32475734960, "failed to allocate 512.0 MiB (12.4/12.4 GiB used)"). 2 threads fits.
+    # It is deliberately NOT 1. Pinning to one writer is what makes rotated files disjoint on
+    # the sort key (locally 1 thread -> 0/6 overlapping pairs, 2 or 4 -> 6/6, because a
+    # multi-threaded COPY writes several files at once and the writers carve the sorted stream
+    # in parallel), but that clustering was measured worth 0.05% of the table here
+    # (19/23 -> 0/2 overlapping pairs moved it 835.08 -> 834.66 MB) and delta-rs, the writer
+    # this is compared against, ships 2/3 overlapping files itself. So overlap is accepted.
+    dd.execute("SET threads=2")
     print(f"{n_src:,} rows -> one sorted single-stream COPY, "
           f"ROW_GROUP_SIZE {RG:,} x FILE_SIZE_BYTES {FILE_BYTES:,} "
           f"x DATA_PAGE_SIZE_LIMIT {PAGE_BYTES:,} x {PQ_VERSION} x DICTIONARY_SIZE_LIMIT "

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -61,10 +61,12 @@ import report  # noqa: E402
 TABLE = os.environ.get("OPT_TABLE") or "fct_summary_auto_sort"
 
 RG = int(os.environ.get("OPT_RG") or 6_000_000)
-# 16M (>= any row group) means NO column ever falls out of dictionary. OPT_DICT_LIMIT=0 omits the
-# option so DuckDB applies its own default (ROW_GROUP_SIZE/5) and high-cardinality columns fall
-# back off dictionary — which is what delta-rs does (its footers carry PLAIN alongside
-# RLE_DICTIONARY) and is worth 2.3x locally on a high-cardinality probe.
+# 16M (>= any row group) means NO column ever falls out of dictionary. KEEP IT THAT WAY: the
+# consuming engine's cheap path is a dictionary-ID remap, so plain values would have to be
+# re-encoded on load. delta-rs instead caps its dictionary PAGE at ~1MB of bytes and spills the
+# rest of the column to PLAIN, which is ~36 MB of why it writes a smaller file — a trade we are
+# deliberately NOT making. OPT_DICT_LIMIT=0 (DuckDB's own value-count default) exists to
+# reproduce that measurement, not as a configuration to ship.
 _dl = (os.environ.get("OPT_DICT_LIMIT") or "").strip()
 DICT_LIMIT = None if _dl == "0" else int(_dl or 16_000_000)
 PAGE_BYTES = int(os.environ.get("OPT_PAGE_BYTES") or 1_048_576)

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -75,6 +75,12 @@ FILE_BYTES = int(float(os.environ.get("OPT_TFS_MB") or 256) * 1024 * 1024)
 PQ_VERSION = (os.environ.get("OPT_PARQUET_VERSION") or "V1").strip().upper()
 if PQ_VERSION not in ("V1", "V2"):
     raise SystemExit(f"build_duckdb_native: OPT_PARQUET_VERSION must be V1 or V2, got {PQ_VERSION!r}")
+# DuckDB writes bloom filters by default; delta-rs does not. They live BETWEEN row groups and are
+# not counted in total_compressed_size, so a per-column footer sum cannot see them — on the real
+# fact they are ~32 MB of the 65 MB delta-rs wins by. Default off, because the reader here is
+# Direct Lake (which does not use parquet bloom filters) and because leaving them on makes the
+# writer A/B measure a feature delta-rs simply doesn't ship.
+BLOOM = (os.environ.get("OPT_BLOOM") or "false").strip().lower() in ("true", "1", "yes")
 sort = (os.environ.get("OPT_SORT") or "date, time").strip()
 if sort.lower() == "auto":
     raise SystemExit("build_duckdb_native: OPT_SORT must be explicit columns (e.g. 'date, time'); "
@@ -160,7 +166,7 @@ else:
     print(f"{n_src:,} rows -> one sorted single-stream COPY, "
           f"ROW_GROUP_SIZE {RG:,} x FILE_SIZE_BYTES {FILE_BYTES:,} "
           f"x DATA_PAGE_SIZE_LIMIT {PAGE_BYTES:,} x {PQ_VERSION} x DICTIONARY_SIZE_LIMIT "
-          f"{f'{DICT_LIMIT:,}' if DICT_LIMIT else 'duckdb default'}", flush=True)
+          f"{f'{DICT_LIMIT:,}' if DICT_LIMIT else 'duckdb default'} x bloom={BLOOM}", flush=True)
     _dict_opt = f"DICTIONARY_SIZE_LIMIT {DICT_LIMIT}," if DICT_LIMIT else ""
     t_s = time.perf_counter()
     dd.execute(f"""
@@ -169,6 +175,7 @@ else:
         (FORMAT parquet, ROW_GROUP_SIZE {RG}, FILE_SIZE_BYTES {FILE_BYTES},
          {_dict_opt} DATA_PAGE_SIZE_LIMIT {PAGE_BYTES},
          COMPRESSION snappy, PARQUET_VERSION {PQ_VERSION},
+         WRITE_BLOOM_FILTER {str(BLOOM).lower()},
          FILENAME_PATTERN 'part-{run_tag}-{{uuid}}', APPEND)
     """)
     print(f"copied in {time.perf_counter() - t_s:.1f}s", flush=True)
@@ -276,6 +283,6 @@ report.merge({"tables": {TABLE: {"build": {
     "engine": "duckdb_copy+delta_commit", "sort": f"sorted by ({sort})", "vorder": False,
     "row_group_ceiling": RG, "dictionary_size_limit": DICT_LIMIT,
     "data_page_size_limit": PAGE_BYTES, "file_size_bytes": FILE_BYTES,
-    "parquet_version": PQ_VERSION,
+    "parquet_version": PQ_VERSION, "bloom_filter": BLOOM,
     "files": k, "rows": n,
     "seconds": round(time.perf_counter() - _t0, 1), "status": status}}}})

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -140,7 +140,11 @@ if not force and _exists():
           flush=True)
     status, k, n = "skipped", None, rows
 else:
-    src = "mart.fct_summary" if N_CAP is None else f"(select * from mart.fct_summary limit {N_CAP})"
+    # BENCH_SOURCE lets a caller read one lakehouse while writing into another (a full expression
+    # such as delta_scan('abfss://.../mart/fct_summary')); the cold benchmark needs that because
+    # its throwaway lakehouse has no mart schema. Same override the delta-rs builder honours.
+    _src_tbl = (os.environ.get("BENCH_SOURCE") or "mart.fct_summary").strip()
+    src = _src_tbl if N_CAP is None else f"(select * from {_src_tbl} limit {N_CAP})"
     n_src = dd.execute(f"select count(*) from {src}").fetchone()[0]
 
     # column types drive the typed stats casts below; the mart already stores decimal(18,4)

--- a/tests/parquet_layout/aemo/sort_key.py
+++ b/tests/parquet_layout/aemo/sort_key.py
@@ -29,10 +29,15 @@ def source_expr():
 
     A bare table name profiles from the Delta LOG (exact row width, and exact when the table fits
     the byte budget); the `limit` form is a subquery, so it falls back to sampling the result
-    relation. Kept identical to build_auto_sort.py's so the key shown is the key built."""
+    relation. Kept identical to build_auto_sort.py's so the key shown is the key built.
+
+    BENCH_SOURCE overrides the table — pass a full expression such as
+    ``delta_scan('abfss://.../mart/fct_summary')`` to read one lakehouse while writing into
+    another, which is what the cold benchmark does with its throwaway lakehouses."""
+    src = (os.environ.get("BENCH_SOURCE") or "mart.fct_summary").strip()
     lim = (os.environ.get("BENCH_ROW_LIMIT") or "").strip()
     n = int(lim) if lim.isdigit() and int(lim) > 0 else None
-    return "mart.fct_summary" if n is None else f"(select * from mart.fct_summary limit {n})"
+    return src if n is None else f"(select * from {src} limit {n})"
 
 
 def requested():

--- a/tests/parquet_layout/writer_cold/cold_bench.py
+++ b/tests/parquet_layout/writer_cold/cold_bench.py
@@ -1,0 +1,144 @@
+"""Cold-only Direct Lake measurement: one pass, one query per column, nothing cached.
+
+WHAT COLD MEANS HERE. The model was deployed minutes ago and has never been queried, so its column
+store is empty. Each query below is the first and only touch of its column, which makes its duration
+the Delta->memory transcode cost of that column plus fixed overhead. There is deliberately no
+`clearValues` dehydrate: forcing a re-transcode before every query is not what a user does, and the
+fresh-model approach is the only non-destructive way to guarantee an empty store. There is also no
+warm or hot pass — the question is exclusively "is this parquet good to read cold".
+
+Because every query must touch a column nothing has touched yet, ORDER MATTERS and the suite must
+not reuse columns. `probe_rowcount` runs last as the ~zero-column control: subtract it to get the
+marginal per-column cost.
+
+`warm_up` is NOT a warm measurement — it is the security-propagation guard. A freshly deployed
+Direct Lake model cannot read OneLake for ~5 min. It uses COUNTROWS only, which reads no column
+data, so it does not warm any column the suite later measures.
+
+Env: PBI_WORKSPACE (display name), ADOMD_DIR, MODEL (catalog), VARIANT (label), RUN_REPORT.
+"""
+import glob
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "aemo"))
+import report  # noqa: E402
+
+# One column per query, cheapest aggregate that still forces a full scan of that column.
+# probe_rowcount LAST: it is the control, and it must not warm anything.
+QUERIES = [
+    ("probe_mw",       'EVALUATE ROW("v", SUM(fct_summary[mw]))'),
+    ("probe_price",    'EVALUATE ROW("v", SUM(fct_summary[price]))'),
+    ("probe_duid",     'EVALUATE ROW("v", DISTINCTCOUNT(fct_summary[DUID]))'),
+    ("probe_date",     'EVALUATE ROW("v", MIN(fct_summary[date]))'),
+    ("probe_time",     'EVALUATE ROW("v", MAX(fct_summary[time]))'),
+    ("probe_rowcount", 'EVALUATE ROW("v", COUNTROWS(fct_summary))'),
+]
+
+
+def _load_adomd(adomd_dir):
+    import clr  # pythonnet
+    hits = glob.glob(os.path.join(adomd_dir, "**", "Microsoft.AnalysisServices.AdomdClient.dll"),
+                     recursive=True)
+    if not hits:
+        sys.exit(f"ADOMD client DLL not found under {adomd_dir!r}")
+    hits.sort(key=lambda p: ("netcore" not in p.lower() and "net6" not in p.lower(), len(p)))
+    d = os.path.dirname(hits[0])
+    if d not in sys.path:
+        sys.path.append(d)
+    clr.AddReference("Microsoft.AnalysisServices.AdomdClient")
+    print(f"Loaded ADOMD from {hits[0]}")
+
+
+def open_conn(workspace, model, token, tries=5, delay=15):
+    """Open an XMLA connection, retrying transient drops (SocketException 10054)."""
+    from Microsoft.AnalysisServices.AdomdClient import AdomdConnection
+    conn_str = (f"Data Source=powerbi://api.powerbi.com/v1.0/myorg/{workspace};"
+                f"Initial Catalog={model};User ID=;Password={token};")
+    last = None
+    for i in range(1, tries + 1):
+        try:
+            conn = AdomdConnection(conn_str)
+            conn.Open()
+            return conn
+        except Exception as e:
+            last = e
+            print(f"  open_conn {i}/{tries} failed ({str(e).splitlines()[0][:100]}); "
+                  f"retrying in {delay}s...", flush=True)
+            time.sleep(delay)
+    raise last
+
+
+def run_query(conn, dax):
+    """Execute dax, drain all rows, return (elapsed_ms, row_count)."""
+    from Microsoft.AnalysisServices.AdomdClient import AdomdCommand
+    t0 = time.perf_counter()
+    reader = AdomdCommand(dax, conn).ExecuteReader()
+    rows = 0
+    try:
+        fc = reader.FieldCount
+        while reader.Read():
+            for i in range(fc):
+                reader.GetValue(i)
+            rows += 1
+    finally:
+        reader.Close()
+    return (time.perf_counter() - t0) * 1000.0, rows
+
+
+def warm_up(conn, model, tries=16, delay=30):
+    """Security-propagation guard, NOT a warm pass: a fresh Direct Lake model cannot read OneLake
+    for ~5 min. COUNTROWS reads no column data, so nothing the suite measures gets warmed."""
+    from Microsoft.AnalysisServices.AdomdClient import AdomdCommand
+    for i in range(1, tries + 1):
+        try:
+            tmsl = json.dumps({"refresh": {"type": "full", "objects": [{"database": model}]}})
+            AdomdCommand(tmsl, conn).ExecuteNonQuery()
+            run_query(conn, 'EVALUATE ROW("n", COUNTROWS(fct_summary))')
+            print(f"  ready after {i} attempt(s)", flush=True)
+            return True
+        except Exception as e:
+            print(f"  not ready {i}/{tries} ({str(e).splitlines()[0][:110]}); waiting {delay}s...",
+                  flush=True)
+            time.sleep(delay)
+    return False
+
+
+def main():
+    workspace = os.environ["PBI_WORKSPACE"]
+    model = os.environ["MODEL"]
+    variant = os.environ.get("VARIANT") or model
+    _load_adomd(os.environ["ADOMD_DIR"])
+
+    from duckrun import auth
+    token = os.environ.get("PBI_TOKEN") or auth.get_powerbi_token()
+    conn = open_conn(workspace, model, token)
+    try:
+        if not warm_up(conn, model):
+            raise SystemExit(f"{model} never became queryable — cannot measure cold")
+
+        results = []
+        print(f"\n=== COLD pass: {variant} ({model}) ===", flush=True)
+        for name, dax in QUERIES:
+            ms, rows = run_query(conn, dax)
+            results.append({"query": name, "cold_ms": round(ms, 1), "rows": rows})
+            print(f"  {name:<16} {ms:>9.1f} ms", flush=True)
+    finally:
+        conn.Close()
+
+    base = next((r["cold_ms"] for r in results if r["query"] == "probe_rowcount"), 0.0)
+    for r in results:
+        r["marginal_ms"] = round(r["cold_ms"] - base, 1)
+    total = round(sum(r["cold_ms"] for r in results), 1)
+    print(f"  {'TOTAL':<16} {total:>9.1f} ms   (control={base} ms)", flush=True)
+
+    report.merge({"cold": {variant: {
+        "model": model, "queries": results, "total_cold_ms": total, "control_ms": base,
+    }}})
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/parquet_layout/writer_cold/cu.py
+++ b/tests/parquet_layout/writer_cold/cu.py
@@ -1,0 +1,212 @@
+"""Read capacity-unit consumption per Fabric item from the Capacity Metrics app.
+
+WHY THIS IS FIDDLY, up front:
+
+* CU keeps accruing for roughly 70 minutes after the work finishes — ingestion lags ~6 min and
+  smoothing spreads a burst over 5-64 min. A read taken right after a run is therefore a genuine
+  LOWER BOUND, not the final bill. `read` records it as such; `settle` re-reads later and keeps
+  max(old, new), so re-reads are idempotent and only ever correct upward.
+* Operation name is the ONLY thing separating compute from storage when they share an item, so
+  everything is grouped by (item, operation) and never collapsed to a single number per item.
+* The metrics model's fact table is DirectQuery (live), but its `Items` dimension is import-mode
+  and lags, so a just-deleted item may have CU rows with no name. We join on GUID and carry our own
+  labels — never on display name.
+* Deleted items keep their CU rows indefinitely. Tearing down the benchmark costs no measurement.
+* Retention is 14 days: any window floor is clamped to now-14d or the query returns nothing useful.
+* Column names differ across app versions, so they are resolved from INFO.VIEW.COLUMNS() rather
+  than hardcoded.
+* One capacity per query — filtering to several returns an opaque "Internal Error".
+
+Usage:  cu.py read    --items '{"deltars":"<guid>",...}' --since-iso <utc> [--label <run id>]
+        cu.py settle  [--run <run id>]        # re-read a past run from the ledger, keep the max
+
+Env: METRICS_WORKSPACE_ID, METRICS_MODEL_ID, CAPACITY_ID, ADOMD_DIR, RUN_REPORT.
+"""
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import cold_bench  # noqa: E402  — reuse _load_adomd / open_conn / run_query
+import report  # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+LEDGER = os.path.join(HERE, "cu_history.json")
+RETENTION_DAYS = 14
+FACT = "Metrics By Item Operation And Hour"
+
+
+def _rows(conn, dax):
+    """Execute dax and return a list of tuples (all columns), unlike cold_bench.run_query which
+    only times and drains."""
+    from Microsoft.AnalysisServices.AdomdClient import AdomdCommand
+    reader = AdomdCommand(dax, conn).ExecuteReader()
+    out = []
+    try:
+        fc = reader.FieldCount
+        while reader.Read():
+            out.append(tuple(reader.GetValue(i) for i in range(fc)))
+    finally:
+        reader.Close()
+    return out
+
+
+def _resolve_columns(conn):
+    """Find the real column names in this version of the app. Getting the date column wrong is the
+    dangerous failure: a 'Datetime' vs 'Date' mixup silently widens the window instead of erroring."""
+    rows = _rows(conn, 'EVALUATE SELECTCOLUMNS(INFO.VIEW.COLUMNS(), "t", [Table], "c", [Name])')
+    cols = [(str(t), str(c)) for t, c in rows]
+    fact_cols = [c for t, c in cols if t == FACT]
+    if not fact_cols:
+        raise SystemExit(f"'{FACT}' not found in the metrics model — is METRICS_MODEL_ID correct? "
+                         f"tables seen: {sorted({t for t, _ in cols})}")
+
+    def pick(*candidates, required=True):
+        for want in candidates:
+            for c in fact_cols:
+                if c.lower() == want.lower():
+                    return c
+        for want in candidates:                      # substring fallback
+            for c in fact_cols:
+                if want.lower() in c.lower():
+                    return c
+        if required:
+            raise SystemExit(f"no column like {candidates} in '{FACT}'; have: {sorted(fact_cols)}")
+        return None
+
+    return {
+        "item": pick("ItemId", "Item Id", "ItemGuid"),
+        "operation": pick("OperationName", "Operation Name", "Operation"),
+        "cu": pick("sum_CU", "CU", "Total CU", "CU (s)"),
+        "date": pick("Date", "Datetime", "DateTime"),
+        "duration": pick("Duration (s)", "sum_duration", "Duration", required=False),
+        "capacity": pick("CapacityId", "Capacity Id", required=False),
+    }
+
+
+def _query(conn, cols, capacity_id, since):
+    since = max(since, dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=RETENTION_DAYS))
+    stamp = since.strftime("%Y-%m-%dT%H:%M:%S")
+    filters = [f"'{FACT}'[{cols['date']}] >= DATEVALUE(\"{since.strftime('%Y-%m-%d')}\")"]
+    if cols["capacity"]:
+        filters.append(f"'{FACT}'[{cols['capacity']}] = \"{capacity_id}\"")
+    measures = [f'"cu", SUM(\'{FACT}\'[{cols["cu"]}])']
+    if cols["duration"]:
+        measures.append(f'"dur", SUM(\'{FACT}\'[{cols["duration"]}])')
+    dax = (f"EVALUATE SUMMARIZECOLUMNS("
+           f"'{FACT}'[{cols['item']}], '{FACT}'[{cols['operation']}], "
+           + ", ".join(f"FILTER(ALL('{FACT}'), {f})" for f in filters) + ", "
+           + ", ".join(measures) + ")")
+    print(f"  window from {stamp}Z, capacity {capacity_id[:8]}...", flush=True)
+    return _rows(conn, dax)
+
+
+def _collect(items, since):
+    cold_bench._load_adomd(os.environ["ADOMD_DIR"])
+    from duckrun import auth
+    token = os.environ.get("PBI_TOKEN") or auth.get_powerbi_token()
+    conn = cold_bench.open_conn(os.environ["METRICS_WORKSPACE_ID"],
+                                os.environ["METRICS_MODEL_ID"], token)
+    try:
+        cols = _resolve_columns(conn)
+        print(f"  resolved columns: {cols}", flush=True)
+        rows = _query(conn, cols, os.environ["CAPACITY_ID"], since)
+    finally:
+        conn.Close()
+
+    wanted = {str(v).lower(): k for k, v in items.items()}
+    out = {k: {} for k in items}
+    for r in rows:
+        guid = str(r[0]).lower()
+        label = wanted.get(guid)
+        if label is None:
+            continue
+        op = str(r[1])
+        cu = float(r[2] or 0)
+        out[label][op] = max(out[label].get(op, 0.0), cu)
+    return out
+
+
+def _load_ledger():
+    if os.path.exists(LEDGER):
+        with open(LEDGER, encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def _save_ledger(led):
+    with open(LEDGER, "w", encoding="utf-8") as f:
+        json.dump(led, f, indent=2, sort_keys=True)
+
+
+def _merge_max(old, new):
+    """CU only ever grows as smoothing lands, so a re-read takes the max. This makes `settle`
+    idempotent and self-correcting for an undercounted first read."""
+    merged = dict(old or {})
+    for op, cu in (new or {}).items():
+        merged[op] = max(float(merged.get(op, 0.0)), float(cu))
+    return merged
+
+
+def _print(per_item, settled):
+    # NB single-line f-string expressions only — CI is Python 3.11, where a multi-line expression
+    # inside the braces is a SyntaxError (PEP 701 relaxed that in 3.12, which is what runs locally).
+    note = "settled" if settled else "LOWER BOUND — CU accrues for ~70 min after the run"
+    print(f"\n## CU by item and operation ({note})", flush=True)
+    for label, ops in sorted(per_item.items()):
+        total = sum(ops.values())
+        print(f"  {label:<10} total {total:>10.1f} CU-s", flush=True)
+        for op, cu in sorted(ops.items(), key=lambda kv: -kv[1]):
+            print(f"      {op:<34} {cu:>10.1f}", flush=True)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("cmd", choices=["read", "settle"])
+    ap.add_argument("--items", help='JSON {"label": "item-guid"}')
+    ap.add_argument("--since-iso", help="UTC start of the run window")
+    ap.add_argument("--label", help="run id used as the ledger key")
+    ap.add_argument("--run", help="settle: ledger key to re-read (default: every unsettled run)")
+    a = ap.parse_args()
+
+    led = _load_ledger()
+    if a.cmd == "read":
+        items = json.loads(a.items)
+        since = dt.datetime.fromisoformat(a.since_iso.replace("Z", "+00:00"))
+        per_item = _collect(items, since)
+        key = a.label or dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        entry = led.get(key, {})
+        entry["items"] = items
+        entry["since"] = since.isoformat()
+        entry["settled"] = False
+        entry["cu"] = {k: _merge_max(entry.get("cu", {}).get(k), v) for k, v in per_item.items()}
+        led[key] = entry
+        _save_ledger(led)
+        _print(per_item, settled=False)
+        report.merge({"cu": {"run": key, "settled": False, "by_item": per_item}})
+        return
+
+    targets = [a.run] if a.run else [k for k, v in led.items() if not v.get("settled")]
+    if not targets:
+        print("nothing to settle", flush=True)
+        return
+    for key in targets:
+        entry = led.get(key)
+        if not entry:
+            raise SystemExit(f"no ledger entry {key!r}; have: {sorted(led)}")
+        since = dt.datetime.fromisoformat(entry["since"])
+        per_item = _collect(entry["items"], since)
+        entry["cu"] = {k: _merge_max(entry.get("cu", {}).get(k), v) for k, v in per_item.items()}
+        # Only call it settled once we are past the ~70 min smoothing tail.
+        age = dt.datetime.now(dt.timezone.utc) - since
+        entry["settled"] = age > dt.timedelta(minutes=75)
+        led[key] = entry
+        print(f"\n{key} (age {age}):", flush=True)
+        _print(entry["cu"], settled=entry["settled"])
+    _save_ledger(led)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/parquet_layout/writer_cold/deploy_models.py
+++ b/tests/parquet_layout/writer_cold/deploy_models.py
@@ -1,0 +1,76 @@
+"""Deploy one fresh Direct Lake model per writer variant, each pointed at its own temp lakehouse.
+
+Freshness is the point: the model must not have existed before this run, because a new dataset is
+the only reliable way to get an empty column store — that is what makes the first query genuinely
+cold. `provision.py drop` deletes them at the end of every run, so a deploy here always creates.
+
+One `.bim` template serves both variants; the only substitution is the partition's `entityName`,
+which is the physical Delta table each model reads. Everything else — logical table name, columns,
+the DAX suite that runs against them — is identical, so any difference in cold time is the parquet.
+
+deploy() itself rewrites the template's placeholder OneLake GUIDs to (this workspace, the named
+lakehouse) and then reframes the model, retrying for several minutes because a brand-new model's
+OneLake read permission takes ~5 min to propagate.
+
+Env: WS_ID, LH_NAME_DELTARS / LH_NAME_DUCKDB, MODEL_DELTARS / MODEL_DUCKDB, TABLE_DELTARS /
+TABLE_DUCKDB (the physical Delta table names).
+"""
+import json
+import os
+import tempfile
+
+import duckrun
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEMPLATE = os.path.join(HERE, "fct_writer.SemanticModel", "model.bim")
+
+VARIANTS = [
+    {"key": "deltars",
+     "model": os.environ.get("MODEL_DELTARS") or "writer_cold_deltars",
+     "lakehouse": os.environ.get("LH_NAME_DELTARS") or "wab_deltars",
+     "table": os.environ.get("TABLE_DELTARS") or "fct_summary_deltars"},
+    {"key": "duckdb",
+     "model": os.environ.get("MODEL_DUCKDB") or "writer_cold_duckdb",
+     "lakehouse": os.environ.get("LH_NAME_DUCKDB") or "wab_duckdb",
+     "table": os.environ.get("TABLE_DUCKDB") or "fct_summary_duckdb"},
+]
+
+
+def main():
+    raw = open(TEMPLATE, encoding="utf-8").read()
+    if "__FACT_TABLE__" not in raw:
+        raise SystemExit("model.bim template lost its __FACT_TABLE__ placeholder")
+    # Guard the setting the whole measurement depends on: without directLakeOnly, Fabric may
+    # silently serve a query via DirectQuery, which measures the SQL endpoint instead of a transcode
+    # and would look like a suspiciously fast cold number.
+    if json.loads(raw.replace("__FACT_TABLE__", "x"))["model"].get(
+            "directLakeBehavior") != "directLakeOnly":
+        raise SystemExit("model.bim must set directLakeBehavior=directLakeOnly — otherwise a cold "
+                         "query can fall back to DirectQuery and measure nothing.")
+
+    ws = duckrun.workspace(os.environ["WS_ID"])
+    out = {}
+    for v in VARIANTS:
+        bim = raw.replace("__FACT_TABLE__", v["table"])
+        path = os.path.join(tempfile.mkdtemp(prefix=f"bim_{v['key']}_"), "model.bim")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(bim)
+        print(f"deploying {v['model']} -> {v['lakehouse']}.tests.{v['table']}", flush=True)
+        ws.deploy(path, lakehouse=v["lakehouse"], name=v["model"], overwrite=True)
+        item = next((i for i in ws.list_items("semanticModels")
+                     if i.get("displayName") == v["model"]), None)
+        if item is None:
+            raise SystemExit(f"deployed {v['model']} but it is not in the workspace listing")
+        out[f"MODEL_ID_{v['key'].upper()}"] = item["id"]
+        print(f"  {v['model']} -> {item['id']}", flush=True)
+
+    gh = os.environ.get("GITHUB_ENV")
+    if gh:
+        with open(gh, "a", encoding="utf-8") as f:
+            f.write("".join(f"{k}={v}\n" for k, v in out.items()))
+    for k, v in out.items():
+        print(f"{k}={v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/parquet_layout/writer_cold/fct_writer.SemanticModel/model.bim
+++ b/tests/parquet_layout/writer_cold/fct_writer.SemanticModel/model.bim
@@ -1,0 +1,79 @@
+{
+  "compatibilityLevel": 1604,
+  "model": {
+    "culture": "en-US",
+    "defaultPowerBIDataSourceVersion": "powerBI_V3",
+    "directLakeBehavior": "directLakeOnly",
+    "expressions": [
+      {
+        "name": "DirectLake",
+        "kind": "m",
+        "description": "Direct Lake connection to OneLake. Both GUIDs are placeholders — duckrun's deploy() rewrites them to the target workspace and lakehouse.",
+        "expression": [
+          "let",
+          "    Source = AzureStorage.DataLake(\"https://onelake.dfs.fabric.microsoft.com/00000000-0000-0000-0000-000000000001/00000000-0000-0000-0000-000000000002\", [HierarchicalNavigation=true])",
+          "in",
+          "    Source"
+        ]
+      }
+    ],
+    "tables": [
+      {
+        "name": "fct_summary",
+        "description": "The table under test. Logical name is identical in both variants so one DAX suite runs unchanged; only the partition's entityName differs, which is the whole experiment.",
+        "columns": [
+          {
+            "name": "date",
+            "dataType": "dateTime",
+            "formatString": "yyyy-MM-dd",
+            "sourceColumn": "date",
+            "sourceLineageTag": "date",
+            "summarizeBy": "none"
+          },
+          {
+            "name": "time",
+            "dataType": "int64",
+            "sourceColumn": "time",
+            "sourceLineageTag": "time",
+            "summarizeBy": "none"
+          },
+          {
+            "name": "DUID",
+            "dataType": "string",
+            "sourceColumn": "DUID",
+            "sourceLineageTag": "DUID",
+            "summarizeBy": "none"
+          },
+          {
+            "name": "mw",
+            "dataType": "decimal",
+            "formatString": "#,##0.00",
+            "sourceColumn": "mw",
+            "sourceLineageTag": "mw",
+            "summarizeBy": "sum"
+          },
+          {
+            "name": "price",
+            "dataType": "decimal",
+            "formatString": "$#,##0.00",
+            "sourceColumn": "price",
+            "sourceLineageTag": "price",
+            "summarizeBy": "none"
+          }
+        ],
+        "partitions": [
+          {
+            "name": "fct_summary",
+            "mode": "directLake",
+            "source": {
+              "type": "entity",
+              "entityName": "__FACT_TABLE__",
+              "expressionSource": "DirectLake",
+              "schemaName": "tests"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/parquet_layout/writer_cold/provision.py
+++ b/tests/parquet_layout/writer_cold/provision.py
@@ -1,0 +1,102 @@
+"""Create and destroy the throwaway Fabric items this benchmark measures in.
+
+Every run builds its own lakehouses and semantic models and deletes them at the end. That is not
+tidiness — it is the measurement design. A **fresh semantic model is the cold guarantee**: nothing
+short of a new dataset reliably empties the resident column store, so "cold" only means anything if
+the model did not exist a minute ago. Fresh items also give fresh GUIDs, which is what makes the CU
+read unambiguous (the Capacity Metrics app aggregates per item GUID, and deleted items keep their
+rows forever, so teardown costs us no measurement).
+
+`create` is idempotent via duckrun's own Workspace.create_lakehouse. `drop` is NOT delegated:
+duckrun's `_delete_item` is best-effort by contract (it swallows non-2xx and logs a warning), which
+in CI means a leaked lakehouse would pass silently and quietly bill storage forever. So the delete
+here goes through `_http_request` and asserts the status itself.
+
+Usage:  provision.py create        (emits LH ids to $GITHUB_ENV)
+        provision.py drop          (deletes models first, then lakehouses; loud on failure)
+
+Env: WS_ID (resolve_env), LH_DELTARS / LH_DUCKDB (names, defaulted), MODEL_DELTARS / MODEL_DUCKDB.
+"""
+import os
+import sys
+
+import duckrun
+from duckrun import auth
+from duckrun.fabric_remote import _FABRIC_API, _http_request
+
+LH = {
+    "deltars": os.environ.get("LH_DELTARS") or "wab_deltars",
+    "duckdb": os.environ.get("LH_DUCKDB") or "wab_duckdb",
+}
+MODELS = {
+    "deltars": os.environ.get("MODEL_DELTARS") or "writer_cold_deltars",
+    "duckdb": os.environ.get("MODEL_DUCKDB") or "writer_cold_duckdb",
+}
+WS_ID = os.environ["WS_ID"]
+
+
+def _ws():
+    # A Workspace caches its control-plane token for the life of the handle, and this job runs long
+    # enough to outlive one. Teardown builds a new handle rather than reusing the create-time token.
+    return duckrun.workspace(WS_ID)
+
+
+def create():
+    ws = _ws()
+    out = {}
+    for key, name in LH.items():
+        lh_id = ws.create_lakehouse(name, schemas=True)
+        out[f"LH_ID_{key.upper()}"] = lh_id
+        out[f"LH_NAME_{key.upper()}"] = name
+        out[f"TABLES_{key.upper()}"] = (
+            f"abfss://{ws.id}@onelake.dfs.fabric.microsoft.com/{lh_id}/Tables")
+        print(f"lakehouse {name} -> {lh_id}", flush=True)
+    gh = os.environ.get("GITHUB_ENV")
+    if gh:
+        with open(gh, "a", encoding="utf-8") as f:
+            f.write("".join(f"{k}={v}\n" for k, v in out.items()))
+    for k, v in out.items():
+        print(f"{k}={v}")
+
+
+def _delete(ws, token, item_id, label):
+    """Delete one item and FAIL LOUDLY. duckrun's own helper deliberately swallows errors."""
+    resp = _http_request("DELETE", f"{_FABRIC_API}/workspaces/{ws.id}/items/{item_id}", token=token)
+    if resp.status_code not in (200, 202, 204, 404):
+        raise SystemExit(f"teardown FAILED to delete {label} ({item_id}): "
+                         f"{resp.status_code} {resp.text[:200]}")
+    print(f"deleted {label} ({item_id})", flush=True)
+
+
+def drop():
+    ws = _ws()
+    token = auth.get_fabric_token()
+    # Models before lakehouses: a model whose Direct Lake source vanished is harmless but confusing,
+    # and deleting in this order keeps the workspace legible if teardown dies halfway.
+    wanted_models = set(MODELS.values())
+    for it in ws.list_items("semanticModels"):
+        if it.get("displayName") in wanted_models:
+            _delete(ws, token, it["id"], f"semanticModel {it['displayName']}")
+    wanted_lh = set(LH.values())
+    for it in ws.list_items("lakehouses"):
+        if it.get("displayName") in wanted_lh:
+            _delete(ws, token, it["id"], f"lakehouse {it['displayName']}")
+
+    # Verify rather than trust: re-list and fail if anything we created is still standing.
+    left = [it["displayName"] for it in ws.list_items("semanticModels")
+            if it.get("displayName") in wanted_models]
+    left += [it["displayName"] for it in ws.list_items("lakehouses")
+             if it.get("displayName") in wanted_lh]
+    if left:
+        raise SystemExit(f"teardown INCOMPLETE — still present: {left}")
+    print("teardown verified: nothing left behind", flush=True)
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "create"
+    if cmd == "create":
+        create()
+    elif cmd == "drop":
+        drop()
+    else:
+        raise SystemExit(f"provision.py: unknown command {cmd!r} (create|drop)")

--- a/tests/parquet_layout/writer_cold/render_cold.py
+++ b/tests/parquet_layout/writer_cold/render_cold.py
@@ -1,0 +1,64 @@
+"""Render the cold comparison to the job summary — the deliverable of the whole workflow.
+
+Two things it deliberately makes visible rather than hiding in a ratio:
+
+* the CONTROL (probe_rowcount) alongside every query, because cold time is
+  fixed-overhead + transcode and only the marginal figure is about the parquet;
+* whether the CU number is settled, because an immediate read is a lower bound.
+"""
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(HERE), "aemo"))
+
+rep_path = os.environ.get("RUN_REPORT", "run_report.json")
+if not os.path.exists(rep_path):
+    raise SystemExit(f"no run report at {rep_path} — nothing to render")
+rep = json.load(open(rep_path, encoding="utf-8"))
+cold = rep.get("cold") or {}
+if not cold:
+    raise SystemExit("run report has no cold results — the benchmark did not get that far")
+
+variants = sorted(cold)
+out = ["## Cold Direct Lake — one pass, nothing cached", ""]
+out.append("Each query is the first touch of its column, so its time is that column's "
+           "Delta→memory transcode plus fixed overhead. `probe_rowcount` is the ~zero-column "
+           "control; `marginal` subtracts it.")
+out.append("")
+out.append("| query | " + " | ".join(f"{v} cold ms" for v in variants)
+           + " | " + " | ".join(f"{v} marginal" for v in variants) + " |")
+out.append("|---|" + "---|" * (2 * len(variants)))
+
+names = [q["query"] for q in cold[variants[0]]["queries"]]
+for n in names:
+    cells, marg = [], []
+    for v in variants:
+        q = next((x for x in cold[v]["queries"] if x["query"] == n), None)
+        cells.append(f"{q['cold_ms']:.1f}" if q else "—")
+        marg.append(f"{q['marginal_ms']:.1f}" if q else "—")
+    out.append(f"| {n} | " + " | ".join(cells) + " | " + " | ".join(marg) + " |")
+out.append("| **total** | "
+           + " | ".join(f"**{cold[v]['total_cold_ms']:.1f}**" for v in variants)
+           + " | " + " | ".join("" for _ in variants) + " |")
+
+cu = rep.get("cu")
+if cu and cu.get("by_item"):
+    state = "settled" if cu.get("settled") else "LOWER BOUND (CU accrues for ~70 min after the run)"
+    out += ["", f"## CU by item — {state}", "",
+            "| item | operation | CU-s |", "|---|---|---|"]
+    for label, ops in sorted(cu["by_item"].items()):
+        for op, val in sorted(ops.items(), key=lambda kv: -kv[1]):
+            out.append(f"| {label} | {op} | {val:.1f} |")
+    if not cu.get("settled"):
+        out += ["", f"Re-read later with `settle_run={cu.get('run')}` to get the settled figure."]
+else:
+    out += ["", "_No CU recorded — the Capacity Metrics read did not run or found nothing._"]
+
+text = "\n".join(out)
+print("\n" + text, flush=True)
+summary = os.environ.get("GITHUB_STEP_SUMMARY")
+if summary:
+    with open(summary, "a", encoding="utf-8") as f:
+        f.write(text + "\n\n")


### PR DESCRIPTION
Adds a cold-only Direct Lake + capacity-unit benchmark, plus the writer-A/B follow-ups from this session.

**Why.** The layout A/B settled the bytes (delta-rs 769.6 MB / 41.7s vs DuckDB 805.8 MB / 57.4s, same
sort key, same geometry, full dictionary both sides) but cannot say whether the DuckDB writer's
parquet is good to *read*. Bytes don't predict cold time here — a 43% byte swing once moved cold by
2% — so this measures it directly.

**Method**, following `djouallah/direct-lake-parquet-layout`: a **fresh semantic model is the cold
guarantee**, because a new dataset is the only reliable way to get an empty column store. So each run
provisions a throwaway lakehouse per writer, builds the table, deploys a brand-new Direct Lake model,
queries once, reads CU, and deletes everything. No `clearValues` dehydrate (forcing a re-transcode
before every query isn't what a user does), no warm pass, no hot pass. One query per column so each
is a genuine first touch, with `probe_rowcount` last as the ~zero-column control.

**Three sharp edges worth review:**
- The model sets `directLakeBehavior: directLakeOnly`, which the existing aemo models do **not**.
  Without it Fabric may silently serve a query via DirectQuery — measuring the SQL endpoint instead
  of a transcode, and looking like a suspiciously good cold number.
- Teardown asserts its own deletes instead of using duckrun's `_delete_item`, which swallows failures
  by contract. A leaked lakehouse should fail the job, not bill quietly.
- CU is read per item GUID **and operation** (operation is the only thing separating compute from
  storage on a shared item) and is labelled an explicit **lower bound**: CU accrues for ~70 min after
  the work, so a `settle` mode re-reads later and keeps `max(old, new)`.

**Requires three new repo secrets before the first run**: `METRICS_WORKSPACE_ID`, `METRICS_MODEL_ID`,
`CAPACITY_ID`. As with `writer_ab.yml`, the workflow must reach the default branch before GitHub will
let it be dispatched.

**Also in here** (writer A/B follow-ups): bloom filters off by default for the DuckDB arm — worth
29.2 MB on the real fact with the dictionary fully intact; a `PARQUET_VERSION` knob, measured
byte-identical between V1 and V2; and the writer capped at 2 threads, which is a memory guard, not a
layout one — unpinned it OOMs the runner, and pinning to 1 buys clustering worth 0.05% of the table.

Test harness only — no `duckrun/` or `dbt/` changes.
