### PR TITLE
test(bench): expose DATA_PAGE_SIZE_LIMIT to the cold benchmark

### DIFF
--- a/.github/workflows/writer_cold.yml
+++ b/.github/workflows/writer_cold.yml
@@ -30,12 +30,16 @@ on:
         type: string
         default: "142000000"
       opt_parquet_version:
-        description: "[duckdb arm] PARQUET_VERSION. V1 tags dictionary data PLAIN_DICTIONARY, V2 tags the IDENTICAL bytes RLE_DICTIONARY (delta-rs always writes the latter). Byte-identical on disk — so if cold time moves, the reader is choosing its path from the tag, not the data."
+        description: "[duckdb arm] PARQUET_VERSION. V1 tags dictionary data PLAIN_DICTIONARY, V2 tags the IDENTICAL bytes RLE_DICTIONARY (delta-rs always writes the latter). MEASURED: the tag changes nothing — the string column cold-read 12492ms on V1 and 12312ms on V2, against delta-rs's 2293ms. Kept as a control."
         type: choice
         default: V1
         options:
           - V1
           - V2
+      opt_page_bytes:
+        description: "[duckdb arm] DATA_PAGE_SIZE_LIMIT. arrow-rs caps a data page at 20,000 ROWS; DuckDB caps by bytes and by a 524,288-row ceiling, so at the 1048576 default its pages hold ~25x more rows than delta-rs's. 65536 lands DuckDB at ~32,768 rows/page — near parity, and free in bytes."
+        type: string
+        default: "1048576"
       order:
         description: "which writer is measured FIRST. The two passes share one capacity, so the second can inherit smoothing/throttling from the first — swap this and re-run to prove an effect is the parquet and not the running order."
         type: choice
@@ -132,6 +136,7 @@ jobs:
           BENCH_SOURCE: delta_scan('${{ env.SRC_TABLES }}/mart/fct_summary')
           OPT_TABLE: ${{ env.TABLE_DUCKDB }}
           OPT_PARQUET_VERSION: ${{ inputs.opt_parquet_version }}
+          OPT_PAGE_BYTES: ${{ inputs.opt_page_bytes }}
           OPT_SORT: ${{ inputs.opt_sort }}
           FORCE_REBUILD: "true"
           BENCH_ROW_LIMIT: ${{ inputs.row_limit }}

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -25,17 +25,27 @@ Shape mechanics, each measured in a local probe before this was written:
     DuckDB's default is ROW_GROUP_SIZE/5, and 1.5.5 dictionary-encodes every type at any NDV
     under the limit. (Exception: DECIMAL(p>18) writes FLBA, never dictionary — the mart already
     stores decimal(18,4), and the post-commit WARN names any column that slips out.)
-  * DATA_PAGE_SIZE_LIMIT caps data pages at ~1MB uncompressed (duckdb#24645, nightly-only until
-    the next stable). This arm's first run died on the old hardcoded 100MB split: ONE giant page
-    per 16M-row column chunk, which the consumer transcodes 5-26x slower (duckdb#24507). ~1MB is
-    the measured sweet spot of the page-size U-curve, and matches what the delta-rs builder has
-    written since d0d23b4. A startup probe fails the build loudly on any duckdb without the
-    option — a stable build would silently write the broken layout and corrupt the A/B.
+  * DATA_PAGE_SIZE_LIMIT caps data pages (duckdb#24645, nightly-only until the next stable). This
+    arm's first run died on the old hardcoded 100MB split: ONE giant page per 16M-row column
+    chunk, which the consumer transcodes 5-26x slower (duckdb#24507). A startup probe fails the
+    build loudly on any duckdb without the option — a stable build would silently write the
+    broken layout and corrupt the A/B.
+    The default 1048576 is NOT parity with delta-rs, despite matching its byte cap: arrow-rs also
+    caps a page at 20,000 ROWS, while DuckDB caps rows only at 524,288 (a power-of-two vector
+    count, so the effective limit steps 2^19 -> 2^17 -> 2^15 as the byte cap falls). Measured on a
+    6M-row group: DuckDB writes 12 pages/chunk at 1MB and 184 at 64KB, against delta-rs's 294.
+    64KB therefore buys near-parity page geometry for no extra bytes — see OPT_PAGE_BYTES.
+  * encoding_stats (PageEncodingStats) is the one footer field we CANNOT match: DuckDB writes
+    none (duckdb#12892, closed as not planned), delta-rs writes
+    DICTIONARY_PAGE/PLAINx1 + DATA_PAGE/RLE_DICTIONARYxN. A consumer that wants to prove a chunk
+    is 100% dictionary-encoded before choosing a transcode path can read that for free from
+    delta-rs and must crack pages open for DuckDB.
 
 Env: ONELAKE_TABLES_PATH (resolve_env), OPT_SORT (explicit columns, default 'date, time' —
 'auto' is the delta-rs builder's spelling and is rejected here), OPT_RG (rows per row group,
 default 6000000 = duckrun's fixed write geometry; the nightly OOM'd the 12.4GiB runner at 4
-threads), OPT_DICT_LIMIT (default 16000000), OPT_PAGE_BYTES (default 1048576),
+threads), OPT_DICT_LIMIT (default 16000000), OPT_PAGE_BYTES (DATA_PAGE_SIZE_LIMIT, default 1048576;
+65536 is the value that lands page geometry near delta-rs's),
 OPT_TFS_MB (file rotation size, default 256 = duckrun's target_file_size_mb),
 OPT_PARQUET_VERSION (V1/V2, byte-identical), OPT_BLOOM (default false — delta-rs writes none,
 and they cost 29.2 MB here), BENCH_ROW_LIMIT, FORCE_REBUILD.


### PR DESCRIPTION
V2 ruled out the encoding tag. Next candidate is page geometry.

Matching delta-rs's 1MB page *byte* cap does not match its page *geometry*: arrow-rs also caps a data page at 20,000 rows, DuckDB has no row knob and its own ceiling is 524,288 rows. Walking page headers off both files, per 6M-row chunk:

| DuckDB DATA_PAGE_SIZE_LIMIT | pages | rows/page |
|---|---|---|
| 1048576 (current default) | 12 | 524,288 |
| 65536 | 184 | 32,768 |
| delta-rs default | 294 | 20,480 |

64KB costs no extra bytes. Wiring the knob into the workflow makes this a single-variable cold run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)