### PR TITLE
test(bench): inject the modern LogicalType into DuckDB footers

### DIFF
--- a/.github/workflows/writer_cold.yml
+++ b/.github/workflows/writer_cold.yml
@@ -40,6 +40,10 @@ on:
         description: "[duckdb arm] DATA_PAGE_SIZE_LIMIT. arrow-rs caps a data page at 20,000 ROWS; DuckDB caps by bytes and by a 524,288-row ceiling, so at the 1048576 default its pages hold ~25x more rows than delta-rs's. 65536 lands DuckDB at ~32,768 rows/page — near parity, and free in bytes."
         type: string
         default: "1048576"
+      opt_logical_type:
+        description: "[duckdb arm] rewrite each footer to add the modern LogicalType (StringType/DateType) that DuckDB omits and delta-rs writes. Footer only — page data is untouched. This is the last unexplained difference between the two writers, and it tracks the cold gap column for column."
+        type: boolean
+        default: false
       order:
         description: "which writer is measured FIRST. The two passes share one capacity, so the second can inherit smoothing/throttling from the first — swap this and re-run to prove an effect is the parquet and not the running order."
         type: choice
@@ -86,6 +90,7 @@ jobs:
       - name: 📦 Install deps (duckrun from THIS tree)
         run: |
           pip install pythonnet pyyaml
+          pip install fastparquet          # footer thrift read/write for opt_logical_type
           pip install -e .
 
       - name: 🦆 Pin duckdb to the nightly that has DATA_PAGE_SIZE_LIMIT (duckdb#24645)
@@ -137,6 +142,7 @@ jobs:
           OPT_TABLE: ${{ env.TABLE_DUCKDB }}
           OPT_PARQUET_VERSION: ${{ inputs.opt_parquet_version }}
           OPT_PAGE_BYTES: ${{ inputs.opt_page_bytes }}
+          OPT_LOGICAL_TYPE: ${{ inputs.opt_logical_type }}
           OPT_SORT: ${{ inputs.opt_sort }}
           FORCE_REBUILD: "true"
           BENCH_ROW_LIMIT: ${{ inputs.row_limit }}

--- a/tests/parquet_layout/aemo/build_duckdb_native.py
+++ b/tests/parquet_layout/aemo/build_duckdb_native.py
@@ -48,7 +48,8 @@ threads), OPT_DICT_LIMIT (default 16000000), OPT_PAGE_BYTES (DATA_PAGE_SIZE_LIMI
 65536 is the value that lands page geometry near delta-rs's),
 OPT_TFS_MB (file rotation size, default 256 = duckrun's target_file_size_mb),
 OPT_PARQUET_VERSION (V1/V2, byte-identical), OPT_BLOOM (default false — delta-rs writes none,
-and they cost 29.2 MB here), BENCH_ROW_LIMIT, FORCE_REBUILD.
+and they cost 29.2 MB here), OPT_LOGICAL_TYPE (default false — rewrite each footer to add the
+modern LogicalType DuckDB omits), BENCH_ROW_LIMIT, FORCE_REBUILD.
 """
 import datetime as _dt
 import decimal as _dec
@@ -94,6 +95,11 @@ if PQ_VERSION not in ("V1", "V2"):
 # Direct Lake (which does not use parquet bloom filters) and because leaving them on makes the
 # writer A/B measure a feature delta-rs simply doesn't ship.
 BLOOM = (os.environ.get("OPT_BLOOM") or "false").strip().lower() in ("true", "1", "yes")
+# DIAGNOSTIC. DuckDB annotates VARCHAR/DATE with the DEPRECATED ConvertedType only; delta-rs writes
+# the modern LogicalType too. Post-processes each footer to add it, changing nothing else — see
+# footer_logical_type.py. This is a measurement knob, not a shipping feature: if it turns out to be
+# the cold-read gap, the fix belongs upstream in DuckDB, not in a footer rewrite.
+LOGICAL_TYPE = (os.environ.get("OPT_LOGICAL_TYPE") or "false").strip().lower() in ("true", "1", "yes")
 sort = (os.environ.get("OPT_SORT") or "date, time").strip()
 if sort.lower() == "auto":
     raise SystemExit("build_duckdb_native: OPT_SORT must be explicit columns (e.g. 'date, time'); "
@@ -199,14 +205,34 @@ else:
     from dbt.adapters.duckrun.objectstore import build_store
     import obstore
     store = build_store(table_uri, con.storage_options)
-    sizes = {}
-    for batch in obstore.list(store):
-        for obj in batch:
-            p = obj["path"]
-            if p.rsplit("/", 1)[-1].startswith(f"part-{run_tag}-"):
-                sizes[p.rsplit("/", 1)[-1]] = obj["size"]
+
+    def _listing():
+        out = {}
+        for batch in obstore.list(store):
+            for obj in batch:
+                p = obj["path"].rsplit("/", 1)[-1]
+                if p.startswith(f"part-{run_tag}-"):
+                    out[p] = obj["size"]
+        return out
+
+    sizes = _listing()
     if not sizes:
         raise SystemExit(f"listing returned no part-{run_tag}-* files")
+
+    # DIAGNOSTIC (OPT_LOGICAL_TYPE): promote ConvertedType-only annotations to the modern
+    # LogicalType. Must happen HERE — after the COPY, before the listing that feeds AddAction.size
+    # — because the rewrite makes each footer a few bytes longer, and a Delta size field that
+    # disagrees with the blob is a worse bug than the one being investigated.
+    if LOGICAL_TYPE:
+        import footer_logical_type
+        print(f"promoting ConvertedType -> LogicalType in {len(sizes)} footer(s)", flush=True)
+        cols = footer_logical_type.patch_remote(store, sorted(sizes))
+        if not cols:
+            raise SystemExit("OPT_LOGICAL_TYPE was set but no column needed promoting — "
+                             "duckdb may have started writing LogicalType itself, which would "
+                             "silently turn this run into a no-op control.")
+        sizes = _listing()          # footers grew; re-read the true sizes
+
     files = sorted(sizes)
     k = len(files)
 

--- a/tests/parquet_layout/aemo/footer_logical_type.py
+++ b/tests/parquet_layout/aemo/footer_logical_type.py
@@ -1,0 +1,83 @@
+"""Inject the modern parquet LogicalType into a DuckDB-written footer. Diagnostic only.
+
+DuckDB annotates a VARCHAR with the DEPRECATED ConvertedType UTF8 and nothing else; delta-rs
+writes that AND `LogicalType.STRING`. Same for DATE. That is the last surviving difference between
+the two writers' footers, and on the cold benchmark it tracks the gap column for column: the two
+columns where DuckDB omits a LogicalType read 7-11x slower, the two where both writers agree read
+~2x slower (the baseline), and the one column where NEITHER writes one is the only column DuckDB
+wins. This module exists to turn that correlation into a causal test.
+
+It rewrites ONLY the footer. Page data is untouched, and every offset in a parquet footer is
+absolute from the start of the file, so truncating at the footer and appending a slightly longer
+one leaves every column chunk exactly where it was. Verified locally on a 2M-row file: data region
+byte-identical, footer 4 bytes longer, and both DuckDB and pyarrow re-read it with zero row-level
+differences.
+
+Fidelity notes, all learned the hard way:
+  * fastparquet's thrift objects will not take a nested struct by assignment from Python, and
+    `_asdict()` round-trips `name` as the repr of a bytes object. So each SchemaElement is rebuilt
+    from its PARSED attributes and the rest of the footer is reused as already-parsed objects.
+  * `i32list` is load-bearing: without it every integer is re-emitted as I64, and an unpatched
+    footer stops being byte-identical to what the writer produced.
+"""
+import struct
+
+MARKER = b"PAR1"
+# ConvertedType ordinal -> the LogicalType union field that means the same thing.
+PROMOTE = {0: "STRING", 6: "DATE"}
+SE_FIELDS = ["type", "type_length", "repetition_type", "name", "num_children",
+             "converted_type", "scale", "precision", "field_id", "logicalType"]
+SE_I32 = [1, 2, 3, 5, 6, 7, 8, 9]          # every SchemaElement field except name and logicalType
+FMD_FIELDS = ["version", "schema", "num_rows", "row_groups", "key_value_metadata",
+              "created_by", "column_orders", "encryption_algorithm",
+              "footer_signing_key_metadata"]
+
+
+def patch_bytes(blob):
+    """Return ``(new_blob, [column names patched])``. ``blob`` is a whole parquet file."""
+    import numpy as np
+    from fastparquet.cencoding import NumpyIO, ThriftObject, from_buffer
+
+    if blob[:4] != MARKER or blob[-4:] != MARKER:
+        raise ValueError("not a parquet file (missing PAR1 marker)")
+    flen = struct.unpack("<I", blob[-8:-4])[0]
+    foot_start = len(blob) - 8 - flen
+    fmd = from_buffer(NumpyIO(np.frombuffer(blob[foot_start:-8], dtype="uint8")), "FileMetaData")
+
+    schema, patched = [], []
+    for se in fmd.schema:
+        kw = {f: getattr(se, f) for f in SE_FIELDS if getattr(se, f) is not None}
+        promo = PROMOTE.get(se.converted_type) if se.logicalType is None else None
+        if promo:
+            kw["logicalType"] = ThriftObject.from_fields("LogicalType", **{promo: {}})
+            name = se.name
+            patched.append(name.decode() if isinstance(name, bytes) else str(name))
+        schema.append(ThriftObject.from_fields("SchemaElement", i32list=SE_I32, **kw))
+    if not patched:
+        return blob, []
+
+    kw = {f: getattr(fmd, f) for f in FMD_FIELDS if getattr(fmd, f) is not None}
+    kw["schema"] = schema
+    footer = bytes(ThriftObject.from_fields("FileMetaData", i32list=[1], **kw).to_bytes())
+    return blob[:foot_start] + footer + struct.pack("<I", len(footer)) + MARKER, patched
+
+
+def patch_remote(store, keys):
+    """Download, patch and replace each key in place. Returns the columns patched on the last file.
+
+    The replace goes back through the same single-PUT path duckrun uses for OneLake overwrites —
+    OneLake rejects a multipart commit over a committed blob.
+    """
+    import obstore
+
+    cols = []
+    for key in keys:
+        blob = bytes(obstore.get(store, key).bytes())
+        new, cols = patch_bytes(blob)
+        if not cols:
+            print(f"  [skip] {key}: nothing to promote", flush=True)
+            continue
+        obstore.put(store, key, new, use_multipart=False)
+        print(f"  [ok] {key}: +{len(new) - len(blob)} footer bytes, promoted {', '.join(cols)}",
+              flush=True)
+    return cols


### PR DESCRIPTION
The last surviving footer difference, and the only one that tracks the cold gap column for column.

| column | delta-rs | DuckDB | cold marginal |
|---|---|---|---|
| DUID | `UTF8 / StringType()` | `UTF8 / —` | 1032 → 12984 ms (11x) |
| date | `DATE / DateType()` | `DATE / —` | 1.9 → 13.3 ms (7x) |
| mw | `DECIMAL / DecimalType(18,4)` | same | 2938 → 5356 (2x) |
| price | `DECIMAL / DecimalType(18,4)` | same | 1061 → 3051 (2x) |
| time | none / none | none / none | 11.5 → 1.8 (DuckDB wins) |

`opt_logical_type` rewrites each footer to add it and changes nothing else. Every offset in a parquet footer is absolute from the start of the file, so truncating at the footer and appending a longer one leaves every page where it was.

Verified locally on a 2M-row file: data region byte-identical, footer 4 bytes longer, DuckDB and pyarrow both re-read it with zero row-level differences, and a second pass promotes nothing. The rewrite runs after the COPY and before the listing that feeds `AddAction.size`, so the Delta log never disagrees with the blob, and it fails loudly if nothing needed promoting.

Diagnostic only — if this is the cause, the fix belongs upstream in DuckDB, not in a footer rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)