### PR TITLE
test(bench): decode the column payload instead of reading headers

### DIFF
--- a/.github/workflows/writer_ab.yml
+++ b/.github/workflows/writer_ab.yml
@@ -59,6 +59,10 @@ on:
         description: "rebuild both tables even if they already exist (else each builder skips)"
         type: boolean
         default: true
+      payload_diff_column:
+        description: "column whose PAYLOAD is decoded and compared at the end of the run — dictionary contents per row group, RLE/bit-packing run framing, and the decoded value sequence. This is the only tool here that decompresses a page rather than reading headers."
+        type: string
+        default: DUID
       page_diff_column:
         description: "column whose PAGE HEADERS are dumped side by side at the end of the run. DUID is the one that reads 11x slower cold; the numeric columns sit at the ~2x baseline."
         type: string
@@ -91,7 +95,7 @@ jobs:
       - name: 📦 Install deps (duckrun from THIS tree)
         run: |
           pip install pyyaml
-          pip install fastparquet          # page-header thrift reader for page_diff.py
+          pip install fastparquet cramjam  # page-header thrift reader + page decompression
           pip install -e .
 
       - name: 🦆 Pin duckdb to the nightly that has DATA_PAGE_SIZE_LIMIT (duckdb#24645)
@@ -146,6 +150,16 @@ jobs:
           PYTHONIOENCODING: utf-8
           PAGE_DIFF_COLUMN: ${{ inputs.page_diff_column }}
         run: python tests/parquet_layout/aemo/page_diff.py
+
+      - name: 🧬 Payload diff — decode the column, do not just read headers
+        # page_diff stops at the page header. This decompresses pages and decodes values, which is
+        # the only place left for two files with identical metadata to actually differ.
+        if: always()
+        continue-on-error: true
+        env:
+          PYTHONIOENCODING: utf-8
+          PAYLOAD_DIFF_COLUMN: ${{ inputs.payload_diff_column }}
+        run: python tests/parquet_layout/aemo/payload_diff.py
 
       - name: 📎 Upload run report
         if: always()

--- a/tests/parquet_layout/aemo/payload_diff.py
+++ b/tests/parquet_layout/aemo/payload_diff.py
@@ -1,0 +1,291 @@
+"""Decode and compare the PAYLOAD of one column between the two writers. Not the headers — the bytes.
+
+Ten cold runs compared metadata and never decoded a value. Every "the data is identical" claim so
+far rests on chunk byte SIZES (6,013,968 vs 6,026,119) and on row group 0 of a synthetic file.
+`page_diff.py` walks page headers and stops; it never decompresses a page. Row groups 1..23 have
+never been looked at by anything.
+
+Direct Lake reads parquet and has no idea which writer produced it, so a 13x gap on one string
+column has to be in the bytes. This decodes them:
+
+  * DICTIONARY per row group — the values, with an ORDER-SENSITIVE hash and a SORTED-SET hash. If a
+    writer's local dictionary permutes or changes content from row group to row group while the
+    other's is stable, that is a real per-segment cost for a consumer that maps local dictionary IDs
+    into one global dictionary, and nothing has looked at it.
+  * RUN FRAMING per data page — the RLE/bit-packing hybrid is a sequence of runs, each either an RLE
+    run (one value, a repeat count) or a bit-packed run (a multiple of 8 values). Two chunks can be
+    the same size with completely different run framing, and run framing is what a decoder's inner
+    loop scales with. Reports bit width, run counts and mean run length.
+  * VALUE SEQUENCE — a hash of the decoded index sequence plus the first values, because if the two
+    writers did not lay the same rows down in the same order then the tables are not comparable and
+    that reframes everything measured so far.
+
+Env: ONELAKE_TABLES_PATH (resolve_env), AB_PREFIX (default 'fct_summary_ab'),
+PAYLOAD_DIFF_COLUMN (default 'DUID'), PAYLOAD_DIFF_PAGES (data pages decoded per row group,
+default 2 — decoding is the expensive part, and run framing is visible in the first page).
+
+Run `python payload_diff.py selftest <duckdb.parquet> <deltars.parquet>` to verify the decoder
+against pyarrow on local files. A decoder that silently mis-parses would MANUFACTURE a difference,
+so that check gates every remote result.
+"""
+import hashlib
+import os
+import struct
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+PREFIX = os.environ.get("AB_PREFIX") or "fct_summary_ab"
+COLUMN = os.environ.get("PAYLOAD_DIFF_COLUMN") or "DUID"
+N_PAGES = int(os.environ.get("PAYLOAD_DIFF_PAGES") or 2)
+
+DICTIONARY_PAGE, DATA_PAGE, DATA_PAGE_V2 = 2, 0, 3
+
+
+def _decompress(raw, codec, n):
+    if codec == 0:
+        return raw
+    import cramjam
+    if codec == 1:                       # SNAPPY — raw block format, NOT the framed one
+        return bytes(cramjam.snappy.decompress_raw(raw))
+    if codec == 2:
+        return bytes(cramjam.gzip.decompress(raw))
+    if codec == 6:
+        return bytes(cramjam.zstd.decompress(raw))
+    raise SystemExit(f"payload_diff: unsupported compression codec {codec}")
+
+
+def _varint(buf, pos):
+    out = shift = 0
+    while True:
+        b = buf[pos]
+        pos += 1
+        out |= (b & 0x7F) << shift
+        if not b & 0x80:
+            return out, pos
+        shift += 7
+
+
+def decode_hybrid(buf, bit_width, max_values):
+    """RLE / bit-packing hybrid -> (values, run stats). The run stats ARE the point of this file."""
+    vals = np.empty(max_values, dtype=np.int64)
+    n = pos = 0
+    rle_runs = bp_runs = 0
+    rle_len, bp_len = [], []
+    byte_w = (bit_width + 7) // 8
+    while n < max_values and pos < len(buf):
+        header, pos = _varint(buf, pos)
+        if header & 1:                                   # bit-packed: (header>>1) groups of 8
+            groups = header >> 1
+            count = groups * 8
+            nbytes = groups * bit_width
+            chunk = buf[pos:pos + nbytes]
+            pos += nbytes
+            if bit_width:
+                bits = np.unpackbits(np.frombuffer(chunk, dtype=np.uint8), bitorder="little")
+                usable = (len(bits) // bit_width) * bit_width
+                v = bits[:usable].reshape(-1, bit_width)
+                weights = (1 << np.arange(bit_width, dtype=np.int64))
+                dec = (v * weights).sum(axis=1)
+            else:
+                dec = np.zeros(count, dtype=np.int64)
+            take = min(count, max_values - n)
+            vals[n:n + take] = dec[:take]
+            n += take
+            bp_runs += 1
+            bp_len.append(count)
+        else:                                            # RLE: one value repeated header>>1 times
+            count = header >> 1
+            v = int.from_bytes(buf[pos:pos + byte_w], "little") if byte_w else 0
+            pos += byte_w
+            take = min(count, max_values - n)
+            vals[n:n + take] = v
+            n += take
+            rle_runs += 1
+            rle_len.append(count)
+    stats = {"bit_width": bit_width, "rle_runs": rle_runs, "bitpacked_runs": bp_runs,
+             "mean_rle_len": round(float(np.mean(rle_len)), 1) if rle_len else 0.0,
+             "mean_bitpacked_len": round(float(np.mean(bp_len)), 1) if bp_len else 0.0}
+    return vals[:n], stats
+
+
+def parse_plain_byte_array(buf, count):
+    """PLAIN dictionary layout for BYTE_ARRAY: (4-byte LE length + bytes) repeated."""
+    out, pos = [], 0
+    for _ in range(count):
+        (ln,) = struct.unpack_from("<I", buf, pos)
+        pos += 4
+        out.append(bytes(buf[pos:pos + ln]))
+        pos += ln
+    return out
+
+
+def decode_chunk(read, meta, optional, phys_type, n_pages):
+    """Decode one column chunk. `read(offset, length) -> bytes` so this works local or remote."""
+    from fastparquet.cencoding import NumpyIO, from_buffer
+
+    start = meta.dictionary_page_offset or meta.data_page_offset
+    blob = read(start, meta.total_compressed_size)
+    io = NumpyIO(np.frombuffer(blob, dtype="uint8"))
+    dictionary, pages, indices = None, [], []
+    while io.tell() < len(blob) - 4 and len(pages) < n_pages:
+        ph = from_buffer(io, "PageHeader")
+        body = blob[io.tell():io.tell() + ph.compressed_page_size]
+        io.seek(ph.compressed_page_size, 1)
+        raw = _decompress(body, meta.codec, ph.uncompressed_page_size)
+        if ph.type == DICTIONARY_PAGE:
+            cnt = ph.dictionary_page_header.num_values
+            dictionary = (parse_plain_byte_array(raw, cnt) if phys_type == 6
+                          else [raw[i:i + 8] for i in range(0, min(len(raw), cnt * 8), 8)])
+            continue
+        if ph.type != DATA_PAGE:                         # V2 not produced by either writer here
+            continue
+        h = ph.data_page_header
+        pos = 0
+        if optional:                                     # def levels: 4-byte LE length, then RLE
+            (dl,) = struct.unpack_from("<I", raw, 0)
+            pos = 4 + dl
+        bit_width = raw[pos]
+        vals, st = decode_hybrid(raw[pos + 1:], bit_width, h.num_values)
+        st["num_values"] = h.num_values
+        st["decoded"] = len(vals)
+        pages.append(st)
+        indices.append(vals)
+    return dictionary, pages, (np.concatenate(indices) if indices else np.empty(0, dtype=np.int64))
+
+
+def _hash(items):
+    h = hashlib.sha256()
+    for x in items:
+        h.update(x if isinstance(x, bytes) else str(x).encode())
+        h.update(b"\x1f")
+    return h.hexdigest()[:16]
+
+
+def analyse(label, files, column, n_pages):
+    """files: list of (name, size, read_fn, footer). Prints per-row-group detail, returns summary."""
+    rows = []
+    for name, _size, read, fmd in files:
+        se = next((s for s in fmd.schema
+                   if (s.name.decode() if isinstance(s.name, bytes) else s.name) == column), None)
+        if se is None:
+            raise SystemExit(f"payload_diff: no column {column!r} in {name}")
+        optional = se.repetition_type == 1
+        for ri, rg in enumerate(fmd.row_groups):
+            cc = next((c for c in rg.columns
+                       if ".".join(x.decode() if isinstance(x, bytes) else x
+                                   for x in c.meta_data.path_in_schema) == column), None)
+            if cc is None:
+                continue
+            d, pages, idx = decode_chunk(read, cc.meta_data, optional, se.type, n_pages)
+            rows.append({
+                "file": name, "rg": ri, "dict_n": len(d) if d else 0,
+                "dict_order_hash": _hash(d) if d else "-",
+                "dict_set_hash": _hash(sorted(d)) if d else "-",
+                "first": [x.decode(errors="replace") for x in (d or [])[:3]],
+                "pages": pages, "idx_hash": _hash(idx[:100_000].tolist()) if len(idx) else "-",
+                "idx_head": idx[:12].tolist(),
+            })
+    print(f"\n{'=' * 108}\n{label}\n{'=' * 108}")
+    print(f"{'rg':>3} {'dict':>5} {'dict order hash':>17} {'dict set hash':>15} {'bw':>3} "
+          f"{'rle':>6} {'bitpk':>6} {'mean bp':>9}  first dict values")
+    for r in rows:
+        p = r["pages"][0] if r["pages"] else {}
+        print(f"{r['rg']:>3} {r['dict_n']:>5} {r['dict_order_hash']:>17} {r['dict_set_hash']:>15} "
+              f"{p.get('bit_width', '-'):>3} {p.get('rle_runs', '-'):>6} "
+              f"{p.get('bitpacked_runs', '-'):>6} {p.get('mean_bitpacked_len', '-'):>9}  "
+              f"{','.join(r['first'])}")
+    order_hashes = {r["dict_order_hash"] for r in rows}
+    set_hashes = {r["dict_set_hash"] for r in rows}
+    print(f"  dictionary IDENTICAL across all {len(rows)} row groups (order-sensitive): "
+          f"{len(order_hashes) == 1}")
+    print(f"  dictionary identical as a SET: {len(set_hashes) == 1}")
+    print(f"  first page index sequence hash: {rows[0]['idx_hash'] if rows else '-'}  "
+          f"head={rows[0]['idx_head'] if rows else '-'}")
+    return rows
+
+
+def main():
+    import obstore
+    import duckrun
+    from dbt.adapters.duckrun.objectstore import build_store
+    from page_diff import read_footer
+
+    root = os.environ["ONELAKE_TABLES_PATH"].rstrip("/")
+    con = duckrun.connect(root, schema="tests")
+    tables = sorted(r[2] for r in con.get_stats(f"{PREFIX}_*").fetchall())
+    if not tables:
+        raise SystemExit(f"payload_diff: no tables matched tests.{PREFIX}_*")
+
+    summary = {}
+    for tbl in tables:
+        store = build_store(f"{root}/tests/{tbl}", con.storage_options)
+        entries = []
+        for batch in obstore.list(store):
+            for obj in batch:
+                nm = obj["path"].rsplit("/", 1)[-1]
+                if nm.endswith(".parquet"):
+                    entries.append((nm, obj["size"]))
+        entries.sort()
+        name, size = entries[0]                          # one file is enough: 8 row groups of it
+
+        def read(off, ln, _k=name, _s=store):
+            return bytes(obstore.get_range(_s, _k, start=off, end=off + ln))
+
+        fmd = read_footer(store, name, size)
+        summary[tbl] = analyse(f"{tbl}  —  {name}", [(name, size, read, fmd)], COLUMN, N_PAGES)
+
+    if len(summary) == 2:
+        a, b = sorted(summary)
+        ra, rb = summary[a][0], summary[b][0]
+        print(f"\n{'=' * 108}\nDIFFERENCES — row group 0, column {COLUMN}\n{'=' * 108}")
+        for key, desc in (("dict_n", "dictionary size"),
+                          ("dict_order_hash", "dictionary VALUES IN ORDER"),
+                          ("dict_set_hash", "dictionary as a set"),
+                          ("idx_hash", "decoded index sequence")):
+            same = ra[key] == rb[key]
+            print(f"{desc:<28}: {'IDENTICAL' if same else 'DIFFERENT'}"
+                  + ("" if same else f"   {a}={ra[key]}  {b}={rb[key]}"))
+        pa = ra["pages"][0] if ra["pages"] else {}
+        pb = rb["pages"][0] if rb["pages"] else {}
+        print(f"\n{'run framing (first data page)':<28}: {a} vs {b}")
+        for k in ("bit_width", "num_values", "rle_runs", "bitpacked_runs",
+                  "mean_rle_len", "mean_bitpacked_len"):
+            print(f"   {k:<25}: {pa.get(k)}   vs   {pb.get(k)}")
+
+
+def selftest(duck_path, delta_path):
+    """The decoder must reproduce pyarrow exactly, on BOTH files, or nothing it says is worth reading."""
+    import fastparquet
+    import pyarrow.parquet as pq
+
+    ok = True
+    for label, path in (("duckdb", duck_path), ("delta-rs", delta_path)):
+        blob = open(path, "rb").read()
+        fmd = fastparquet.ParquetFile(path).fmd
+        se = next(s for s in fmd.schema
+                  if (s.name.decode() if isinstance(s.name, bytes) else s.name) == COLUMN)
+        cc = next(c for c in fmd.row_groups[0].columns
+                  if ".".join(x.decode() if isinstance(x, bytes) else x
+                              for x in c.meta_data.path_in_schema) == COLUMN)
+        d, pages, idx = decode_chunk(lambda o, l: blob[o:o + l], cc.meta_data,
+                                     se.repetition_type == 1, se.type, 1)
+        mine = [d[i].decode() for i in idx[:5000]]
+        theirs = pq.read_table(path, columns=[COLUMN]).column(0).to_pylist()[:5000]
+        match = mine == theirs
+        ok &= match
+        print(f"{label:<9} dict={len(d)} bit_width={pages[0]['bit_width']} "
+              f"decoded={len(idx):,} round-trip vs pyarrow: {match}")
+        if not match:
+            bad = next(i for i in range(len(mine)) if mine[i] != theirs[i])
+            print(f"          first mismatch at {bad}: mine={mine[bad]!r} pyarrow={theirs[bad]!r}")
+    print("\nDECODER VERIFIED" if ok else "\nDECODER IS WRONG — fix it before trusting any output")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "selftest":
+        sys.exit(selftest(sys.argv[2], sys.argv[3]))
+    main()


### PR DESCRIPTION
Direct Lake reads parquet and has no idea who wrote it, so the 13× gap is in the bytes. Ten runs compared **metadata** and never decoded a value — `page_diff.py` stops at the page header, every "data is identical" claim rests on chunk byte *sizes*, and row groups 1–23 have never been looked at.

`payload_diff.py` decompresses and decodes. Per row group: dictionary values with order-sensitive **and** sorted-set hashes, RLE/bit-packing run framing (bit width, run counts, mean run length), and a hash of the decoded index sequence.

A mis-parsing decoder would *manufacture* a difference, so it ships with a selftest that must reproduce pyarrow exactly on both writers before any output is trusted:

```
duckdb    dict=500 bit_width=9 decoded=524,288 round-trip vs pyarrow: True
delta-rs  dict=500 bit_width=8 decoded=932,864 round-trip vs pyarrow: True
DECODER VERIFIED
```

That already shows something no header-level tool could see: the same 500-value dictionary encoded at **bit width 9 by DuckDB and 8 by delta-rs**. 8 is byte-aligned; 9 is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)